### PR TITLE
⚡ Bolt: Avoid string allocations in URLSearchParams constructor

### DIFF
--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -85,13 +85,21 @@ impl URLSearchParamsMethods<crate::DomTypeHolder> for URLSearchParams {
                 }
 
                 // Step 2-2.
-                *query.list.borrow_mut() =
-                    init.iter().map(|pair| (pair[0].to_string(), pair[1].to_string())).collect::<Vec<_>>();
+                *query.list.borrow_mut() = init
+                    .into_iter()
+                    .map(|mut pair| {
+                        let value = pair.pop().unwrap().0;
+                        let name = pair.pop().unwrap().0;
+                        (name, value)
+                    })
+                    .collect::<Vec<_>>();
             },
             USVStringSequenceSequenceOrUSVStringUSVStringRecordOrUSVString::USVStringUSVStringRecord(init) => {
                 // Step 3.
-                *query.list.borrow_mut() =
-                    (*init).iter().map(|(name, value)| (name.to_string(), value.to_string())).collect::<Vec<_>>();
+                *query.list.borrow_mut() = (*init)
+                    .into_iter()
+                    .map(|(name, value)| (name.0, value.0))
+                    .collect::<Vec<_>>();
             },
             USVStringSequenceSequenceOrUSVStringUSVStringRecordOrUSVString::USVString(init) => {
                 // Step 4.


### PR DESCRIPTION
⚡ Bolt: Avoid string allocations in URLSearchParams constructor

💡 What:
Replaced `.iter().map(|pair| (pair[0].to_string(), ...))` with `.into_iter().map(|mut pair| ...)` to consume the input `Vec<Vec<USVString>>`.
Similarly optimized the Record variant.

🎯 Why:
The original code cloned every string (name and value) when constructing `URLSearchParams`, even though the input `init` was passed by value (owned). This caused unnecessary heap allocations.

📊 Impact:
Reduces allocations by 2 * N (where N is number of params).
For large initializers, this is a significant memory and CPU saving.
Verify with `cargo bench` (if available) or code inspection showing clones are removed.

🔬 Measurement:
Verified logic with standalone script confirming `into_iter` + `pop` correctly reconstructs pairs without cloning.
Verified `USVString` structure allows access to inner `String`.

---
*PR created automatically by Jules for task [10231200332966426040](https://jules.google.com/task/10231200332966426040) started by @RingCanary*