### PR TITLE
⚡ Bolt: Optimize DocumentTree allocation

### DIFF
--- a/components/script/document_collection.rs
+++ b/components/script/document_collection.rs
@@ -138,6 +138,7 @@ struct DocumentTree {
 impl DocumentTree {
     fn new(documents: &DocumentCollection) -> Self {
         let mut tree = DocumentTree::default();
+        tree.tree.reserve(documents.map.len());
         for (id, document) in documents.iter() {
             let children: Vec<PipelineId> = document
                 .iframes()
@@ -154,7 +155,7 @@ impl DocumentTree {
     }
 
     fn documents_in_order(&self) -> Vec<PipelineId> {
-        let mut list = Vec::new();
+        let mut list = Vec::with_capacity(self.tree.len());
         for (id, node) in self.tree.iter() {
             if node.parent.is_none() {
                 self.process_node_for_documents_in_order(*id, &mut list);

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -138,6 +138,11 @@ impl<K, V, S> HashMapTracedValues<K, V, S> {
     pub(crate) fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+
+    #[inline]
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
 }
 
 impl<K, V, S> HashMapTracedValues<K, V, S>


### PR DESCRIPTION
💡 What: Optimized memory allocation in `DocumentTree` construction and traversal.
🎯 Why: `ScriptThread::update_the_rendering` calls `documents_in_order` frequently (potentially every frame). The previous implementation constructed a new HashMap and Vector with default capacities, leading to multiple re-allocations as they grew.
📊 Impact: Reduces allocation churn by pre-allocating exact sizes. O(1) allocation overhead instead of O(log N) re-allocations.
🔬 Measurement: Verified manually. `cargo check` fails due to environment issues (missing llvm-objdump), but logic is standard safe Rust.


---
*PR created automatically by Jules for task [3417409700228224724](https://jules.google.com/task/3417409700228224724) started by @RingCanary*