### PR TITLE
⚡ Bolt: Optimize DocumentTree allocation

### DIFF
--- a/components/script/document_collection.rs
+++ b/components/script/document_collection.rs
@@ -138,6 +138,8 @@ struct DocumentTree {
 impl DocumentTree {
     fn new(documents: &DocumentCollection) -> Self {
         let mut tree = DocumentTree::default();
+        // Bolt: Pre-allocate map capacity to avoid resizing during insertion (O(n)).
+        tree.tree.reserve(documents.map.0.len());
         for (id, document) in documents.iter() {
             let children: Vec<PipelineId> = document
                 .iframes()
@@ -154,7 +156,8 @@ impl DocumentTree {
     }
 
     fn documents_in_order(&self) -> Vec<PipelineId> {
-        let mut list = Vec::new();
+        // Bolt: Pre-allocate vector capacity to avoid reallocations (O(n)).
+        let mut list = Vec::with_capacity(self.tree.len());
         for (id, node) in self.tree.iter() {
             if node.parent.is_none() {
                 self.process_node_for_documents_in_order(*id, &mut list);


### PR DESCRIPTION
💡 What: Optimized memory allocation in `DocumentTree` creation and traversal.
🎯 Why: `DocumentTree` construction and traversal happen during rendering updates. Repeatedly pushing to a `Vec` or inserting into a `HashMap` without pre-allocation causes unnecessary reallocations and copying.
📊 Impact: Reduces allocation churn. The size of the document collection is known, so we can allocate exact capacity.
🔬 Measurement: Verified by code inspection (standard Rust optimization). `cargo test` and `cargo check` failed due to unrelated environment issues (`llvm-objdump` missing).


---
*PR created automatically by Jules for task [4683219107622270130](https://jules.google.com/task/4683219107622270130) started by @RingCanary*