### PR TITLE
⚡ Bolt: Optimize DocumentTree allocation in script

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - DocumentTree Allocation Churn
+**Learning:** The `DocumentTree` is reconstructed on every call to `documents_in_order`, which is likely called during rendering updates. This involves allocating a new HashMap and a new Vec every time.
+**Action:** Pre-allocate collections using `with_capacity` based on the known number of documents (`DocumentCollection::len()`) to minimize reallocation overhead.

--- a/components/script/document_collection.rs
+++ b/components/script/document_collection.rs
@@ -137,7 +137,9 @@ struct DocumentTree {
 
 impl DocumentTree {
     fn new(documents: &DocumentCollection) -> Self {
-        let mut tree = DocumentTree::default();
+        let mut tree = DocumentTree {
+            tree: FxHashMap::with_capacity_and_hasher(documents.map.0.len(), Default::default()),
+        };
         for (id, document) in documents.iter() {
             let children: Vec<PipelineId> = document
                 .iframes()
@@ -154,7 +156,7 @@ impl DocumentTree {
     }
 
     fn documents_in_order(&self) -> Vec<PipelineId> {
-        let mut list = Vec::new();
+        let mut list = Vec::with_capacity(self.tree.len());
         for (id, node) in self.tree.iter() {
             if node.parent.is_none() {
                 self.process_node_for_documents_in_order(*id, &mut list);


### PR DESCRIPTION
💡 What: Pre-allocate `DocumentTree` HashMap and `documents_in_order` Vec using `with_capacity`.
🎯 Why: `DocumentTree` is rebuilt on every rendering update (via `documents_in_order`). Pre-allocating prevents unnecessary reallocations as the collections grow.
📊 Impact: Reduces allocation churn for the `tree` HashMap and result vector, improving performance in hot rendering paths.
🔬 Measurement: Verified code structure to ensure `len()` access is O(1) and valid.

---
*PR created automatically by Jules for task [10551256540292109340](https://jules.google.com/task/10551256540292109340) started by @RingCanary*