### PR TITLE
Implement wait for element to be keyboard-interactable in WebDriver Send Keys

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1264,8 +1264,9 @@ pub(crate) fn handle_will_send_keys(
         // Step 7.1. Scroll into view the element
         scroll_into_view(&element, documents, &pipeline, can_gc);
 
-        // TODO: Step 7.2 - 7.5
+        // Step 7.2 - 7.5
         // Wait until element become keyboard-interactable
+        // This is handled by implicit_wait in webdriver_server.
 
         // Step 7.6. If element is not keyboard-interactable,
         // return ErrorStatus::ElementNotInteractable.

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -431,7 +431,6 @@ enum VerifyBrowsingContextIsOpen {
 
 enum ImplicitWait {
     Return,
-    #[expect(dead_code, reason = "This will be used in the next patch")]
     Continue,
 }
 
@@ -2186,18 +2185,33 @@ impl Handler {
         // Step 4. Handle any user prompt.
         self.handle_any_user_prompts(self.webview_id()?)?;
 
-        let (sender, receiver) = generic_channel::channel().unwrap();
-        let cmd = WebDriverScriptCommand::WillSendKeys(
-            element.to_string(),
-            keys.text.to_string(),
-            self.session()?.strict_file_interactability(),
-            sender,
-        );
-        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
+        let result = self.implicit_wait(|| {
+            let (sender, receiver) = generic_channel::channel().unwrap();
+            let cmd = WebDriverScriptCommand::WillSendKeys(
+                element.to_string(),
+                keys.text.to_string(),
+                self.session()
+                    .map_err(|e| (ImplicitWait::Return.into(), e))?
+                    .strict_file_interactability(),
+                sender,
+            );
+            self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)
+                .map_err(|e| (ImplicitWait::Return.into(), e))?;
+
+            wait_for_ipc_response_flatten(receiver)
+                .map(|x| (true, x))
+                .map_err(|e| {
+                    if e.error == ErrorStatus::ElementNotInteractable {
+                        (ImplicitWait::Continue.into(), e)
+                    } else {
+                        (ImplicitWait::Return.into(), e)
+                    }
+                })
+        })?;
 
         // File input and non-typeable form control should have
         // been handled in `webdriver_handler.rs`.
-        if !wait_for_ipc_response_flatten(receiver)? {
+        if !result {
             return Ok(WebDriverResponse::Void);
         }
 


### PR DESCRIPTION
Implemented the wait logic for "Element Send Keys" command in WebDriver.

* Modified `components/webdriver_server/lib.rs` to use `implicit_wait` when handling `ElementSendKeys`. This ensures that if the element is not interactable (e.g. not visible), it waits up to the session's implicit wait timeout before failing.
* Updated `components/script/webdriver_handlers.rs` to remove the TODO comment, as the waiting logic is now effectively handled by the server retrying the command.


---
*PR created automatically by Jules for task [4771720899461489260](https://jules.google.com/task/4771720899461489260) started by @RingCanary*