### PR TITLE
Cleanup Indexed Database transactions in microtask checkpoint

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -121,6 +121,7 @@ use crate::dom::eventsource::EventSource;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::file::File;
 use crate::dom::idbfactory::IDBFactory;
+use crate::dom::indexeddb::idbtransaction::IDBTransaction;
 use crate::dom::messageport::MessagePort;
 use crate::dom::paintworkletglobalscope::PaintWorkletGlobalScope;
 use crate::dom::performance::performance::Performance;
@@ -416,6 +417,10 @@ pub(crate) struct GlobalScope {
     /// <https://fetch.spec.whatwg.org/#environment-settings-object-fetch-group>
     #[no_trace]
     fetch_group: RefCell<FetchGroup>,
+
+    /// List of active IndexedDB transactions to be cleaned up at microtask checkpoint.
+    /// <https://w3c.github.io/IndexedDB/#cleanup-indexed-database-transactions>
+    idb_transaction_list: DomRefCell<Vec<Dom<IDBTransaction>>>,
 }
 
 /// A wrapper for glue-code between the ipc router and the event-loop.
@@ -826,6 +831,7 @@ impl GlobalScope {
             resolved_module_set: Default::default(),
             font_context,
             fetch_group: Default::default(),
+            idb_transaction_list: Default::default(),
         }
     }
 
@@ -3474,6 +3480,30 @@ impl GlobalScope {
             .get(deferred_fetch_record_id)
             .expect("Should always use a generated fetch_record_id instead of passing your own")
             .clone()
+    }
+
+    pub(crate) fn register_idb_transaction(&self, transaction: &IDBTransaction) {
+        self.idb_transaction_list
+            .borrow_mut()
+            .push(Dom::from_ref(transaction));
+    }
+
+    /// <https://w3c.github.io/IndexedDB/#cleanup-indexed-database-transactions>
+    pub(crate) fn cleanup_indexed_db_transactions(&self) {
+        let mut transactions = self.idb_transaction_list.borrow_mut();
+        // Step 1. For each transaction transaction, proceed to the next step.
+        // We drain the list because transactions only need to be processed once here.
+        // If they remain active (because of pending requests), they will be committed
+        // when the requests finish.
+        for transaction in transactions.drain(..) {
+            // Step 2. If the transaction’s active flag is true, set it to false.
+            if transaction.is_active() {
+                transaction.set_active_flag(false);
+            }
+            // Step 3. If the transaction’s request list is empty, then commit transaction.
+            // Note: set_active_flag(false) will automatically trigger commit (via dispatch_complete)
+            // if the request list is empty.
+        }
     }
 
     /// <https://fetch.spec.whatwg.org/#process-deferred-fetches>

--- a/components/script/dom/indexeddb/idbtransaction.rs
+++ b/components/script/dom/indexeddb/idbtransaction.rs
@@ -100,7 +100,7 @@ impl IDBTransaction {
         can_gc: CanGc,
     ) -> DomRoot<IDBTransaction> {
         let serial_number = IDBTransaction::register_new(global, connection.get_name());
-        reflect_dom_object(
+        let transaction = reflect_dom_object(
             Box::new(IDBTransaction::new_inherited(
                 connection,
                 mode,
@@ -110,7 +110,9 @@ impl IDBTransaction {
             )),
             global,
             can_gc,
-        )
+        );
+        global.register_idb_transaction(&transaction);
+        transaction
     }
 
     /// Create a new WebIDL object,
@@ -125,7 +127,7 @@ impl IDBTransaction {
         open_request_id: Option<Uuid>,
         can_gc: CanGc,
     ) -> DomRoot<IDBTransaction> {
-        reflect_dom_object(
+        let transaction = reflect_dom_object(
             Box::new(IDBTransaction::new_inherited(
                 connection,
                 mode,
@@ -135,7 +137,9 @@ impl IDBTransaction {
             )),
             global,
             can_gc,
-        )
+        );
+        global.register_idb_transaction(&transaction);
+        transaction
     }
 
     // Registers a new transaction in the idb thread, and gets an unique serial number in return.

--- a/components/script/microtask.rs
+++ b/components/script/microtask.rs
@@ -171,11 +171,14 @@ impl MicrotaskQueue {
         // Step 4. For each environment settings object settingsObject whose responsible
         // event loop is this event loop, notify about rejected promises given
         // settingsObject's global object.
-        for global in globalscopes.into_iter() {
-            notify_about_rejected_promises(&global);
+        for global in globalscopes.iter() {
+            notify_about_rejected_promises(global);
         }
 
-        // TODO: Step 5. Cleanup Indexed Database transactions.
+        // Step 5. Cleanup Indexed Database transactions.
+        for global in globalscopes.iter() {
+            global.cleanup_indexed_db_transactions();
+        }
 
         // TODO: Step 6. Perform ClearKeptObjects().
 


### PR DESCRIPTION
Implemented cleanup of Indexed Database transactions in microtask checkpoint as per HTML and IndexedDB specifications.
- Added `idb_transaction_list` to `GlobalScope` to track active transactions.
- Updated `IDBTransaction` to register itself with `GlobalScope` upon creation.
- Implemented `cleanup_indexed_db_transactions` in `GlobalScope` to deactivate transactions and potentially commit them if no requests are pending.
- Updated `MicrotaskQueue::checkpoint` to call cleanup on global scopes.

---
*PR created automatically by Jules for task [11151777689571206649](https://jules.google.com/task/11151777689571206649) started by @RingCanary*