### PR TITLE
Fix Location to return active document if same origin but not fully active

### DIFF
--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -198,14 +198,15 @@ impl Location {
             // > its origin is not same origin-domain with the entry settings
             // > object's origin, then throw a "SecurityError" `DOMException`.
             //
-            // FIXME: We should still return the active document if it's same
-            //        origin but not fully active. `WindowProxy::document`
-            //        currently returns `None` in this case.
-            if let Some(document) = window_proxy.document().filter(|document| {
-                self.entry_settings_object()
-                    .origin()
-                    .same_origin_domain(document.origin())
-            }) {
+            if let Some(document) = window_proxy
+                .document()
+                .or_else(|| Some(self.window.Document()))
+                .filter(|document| {
+                    self.entry_settings_object()
+                        .origin()
+                        .same_origin_domain(document.origin())
+                })
+            {
                 Ok(Some(document))
             } else {
                 Err(Error::Security(None))


### PR DESCRIPTION
Implemented a fallback in `Location::document_if_same_origin` to return `self.window.Document()` if `window_proxy.document()` returns `None`. This addresses the FIXME where `WindowProxy::document` currently returns `None` when the document is not fully active (e.g., inactive iframe) even if it is same-origin and technically the active document of the browsing context.

---
*PR created automatically by Jules for task [6801675429370924977](https://jules.google.com/task/6801675429370924977) started by @RingCanary*