### PR TITLE
Fix Location access for same-origin suspended documents

### DIFF
--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -197,10 +197,6 @@ impl Location {
             // > If this `Location` object's relevant `Document` is non-null and
             // > its origin is not same origin-domain with the entry settings
             // > object's origin, then throw a "SecurityError" `DOMException`.
-            //
-            // FIXME: We should still return the active document if it's same
-            //        origin but not fully active. `WindowProxy::document`
-            //        currently returns `None` in this case.
             if let Some(document) = window_proxy.document().filter(|document| {
                 self.entry_settings_object()
                     .origin()

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3310,7 +3310,11 @@ impl Window {
 
         // Set the window proxy to be a cross-origin window.
         if self.window_proxy().currently_active() == Some(self.global().pipeline_id()) {
-            self.window_proxy().unset_currently_active(can_gc);
+            if self.is_top_level() {
+                self.window_proxy().unset_currently_active(can_gc);
+            } else {
+                self.window_proxy().suspend_active_document(can_gc);
+            }
         }
 
         // A hint to the JS runtime that now would be a good time to

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -784,6 +784,21 @@ impl WindowProxy {
         self.currently_active.set(None);
     }
 
+    pub(crate) fn suspend_active_document(&self, can_gc: CanGc) {
+        if self.currently_active().is_none() {
+            return debug!(
+                "Attempt to suspend the currently active window on a windowproxy that does not have one."
+            );
+        }
+        let globalscope = self.global();
+        let window = DissimilarOriginWindow::new(&globalscope, self);
+        self.set_window(
+            window.upcast(),
+            WindowProxyHandler::x_origin_proxy_handler(),
+            can_gc,
+        );
+    }
+
     pub(crate) fn currently_active(&self) -> Option<PipelineId> {
         self.currently_active.get()
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2891,6 +2891,8 @@ impl ScriptThread {
                 // will be discarded.
                 None,
             );
+        } else if let Some(proxy) = self.window_proxies.get(browsing_context_id) {
+            proxy.unset_currently_active(can_gc);
         }
     }
 


### PR DESCRIPTION
This PR fixes an issue where `Location` operations (like reload) would fail on same-origin but suspended documents (e.g. detached iframes or iframes in bfcached pages) because `WindowProxy::document()` returned `None`.

The fix involves preserving the `currently_active` pipeline ID in `WindowProxy` when a nested browsing context is suspended but not replaced, while ensuring it is cleared when replaced by a cross-origin document.

Changes:
- `components/script/dom/windowproxy.rs`: Add `suspend_active_document`.
- `components/script/dom/window.rs`: Use `suspend_active_document` for nested windows in `suspend`.
- `components/script/script_thread.rs`: Clear active document in `WindowProxy` when iframe navigates to remote pipeline.
- `components/script/dom/location.rs`: Remove FIXME.

---
*PR created automatically by Jules for task [13921672132140030897](https://jules.google.com/task/13921672132140030897) started by @RingCanary*