### PR TITLE
Implement service worker termination

### DIFF
--- a/components/script/dom/workers/abstractworkerglobalscope.rs
+++ b/components/script/dom/workers/abstractworkerglobalscope.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::time::Instant;
+
 use crossbeam_channel::{Receiver, select};
 use devtools_traits::DevtoolScriptControlMsg;
 use rustc_hash::FxHashSet;
@@ -31,6 +33,11 @@ pub(crate) trait WorkerEventLoopMethods {
     fn from_devtools_msg(msg: DevtoolScriptControlMsg) -> Self::Event;
     fn from_timer_msg() -> Self::Event;
     fn control_receiver(&self) -> &Receiver<Self::ControlMsg>;
+
+    fn timeout_receiver(&self) -> Receiver<Instant> {
+        crossbeam_channel::never()
+    }
+    fn from_timeout_msg() -> Self::Event;
 }
 
 // https://html.spec.whatwg.org/multipage/#worker-event-loop
@@ -60,6 +67,7 @@ pub(crate) fn run_worker_event_loop<T, WorkerMsg, Event>(
         // RoutedReceivers have two results
         recv(devtools_receiver) -> msg => T::from_devtools_msg(msg.unwrap().unwrap()),
         recv(scope.timer_scheduler().wait_channel()) -> _ => T::from_timer_msg(),
+        recv(worker_scope.timeout_receiver()) -> _ => T::from_timeout_msg(),
     };
 
     scope.timer_scheduler().dispatch_completed_timers();

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -105,6 +105,7 @@ pub(crate) enum MixedMessage {
     Worker(DedicatedWorkerScriptMsg),
     Devtools(DevtoolScriptControlMsg),
     Control(DedicatedWorkerControlMsg),
+    Timeout,
     Timer,
 }
 
@@ -236,6 +237,10 @@ impl WorkerEventLoopMethods for DedicatedWorkerGlobalScope {
 
     fn from_timer_msg() -> MixedMessage {
         MixedMessage::Timer
+    }
+
+    fn from_timeout_msg() -> MixedMessage {
+        MixedMessage::Timeout
     }
 
     fn control_receiver(&self) -> &Receiver<DedicatedWorkerControlMsg> {
@@ -653,6 +658,9 @@ impl DedicatedWorkerGlobalScope {
                 return false;
             },
             MixedMessage::Timer => {},
+            MixedMessage::Timeout => {
+                warn!("Received unexpected timeout message in DedicatedWorker");
+            },
         }
         true
     }

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -134,6 +134,7 @@ pub(crate) enum MixedMessage {
     ServiceWorker(ServiceWorkerScriptMsg),
     Devtools(DevtoolScriptControlMsg),
     Control(ServiceWorkerControlMsg),
+    Timeout,
     Timer,
 }
 
@@ -211,8 +212,16 @@ impl WorkerEventLoopMethods for ServiceWorkerGlobalScope {
         MixedMessage::Timer
     }
 
+    fn from_timeout_msg() -> MixedMessage {
+        MixedMessage::Timeout
+    }
+
     fn control_receiver(&self) -> &Receiver<ServiceWorkerControlMsg> {
         &self.control_receiver
+    }
+
+    fn timeout_receiver(&self) -> Receiver<Instant> {
+        self.time_out_port.clone()
     }
 }
 
@@ -459,6 +468,9 @@ impl ServiceWorkerGlobalScope {
             },
             MixedMessage::Control(ServiceWorkerControlMsg::Exit) => {
                 return false;
+            },
+            MixedMessage::Timeout => {
+                let _ = self.swmanager_sender.send(ServiceWorkerMsg::Timeout(self.scope_url.clone()));
             },
             MixedMessage::Timer => {},
         }

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -90,36 +90,7 @@ enum RegistrationUpdateTarget {
 impl Drop for ServiceWorkerRegistration {
     /// <https://html.spec.whatwg.org/multipage/#terminate-a-worker>
     fn drop(&mut self) {
-        // Drop the channel to signal shutdown.
-        if self
-            .control_sender
-            .take()
-            .expect("No control sender to worker thread.")
-            .send(ServiceWorkerControlMsg::Exit)
-            .is_err()
-        {
-            warn!("Failed to send exit message to service worker scope.");
-        }
-
-        self.closing
-            .take()
-            .expect("No close flag for worker")
-            .store(true, Ordering::SeqCst);
-        self.context
-            .take()
-            .expect("No context to request interrupt.")
-            .request_interrupt_callback();
-
-        // TODO: Step 1, 2 and 3.
-        if self
-            .join_handle
-            .take()
-            .expect("No handle to join on worker.")
-            .join()
-            .is_err()
-        {
-            warn!("Failed to join on service worker thread.");
-        }
+        self.terminate_worker();
     }
 }
 
@@ -176,6 +147,30 @@ impl ServiceWorkerRegistration {
 
         assert!(self.closing.is_none());
         self.closing = Some(closing);
+    }
+
+    /// <https://w3c.github.io/ServiceWorker/#terminate-service-worker>
+    fn terminate_worker(&mut self) {
+        // Drop the channel to signal shutdown.
+        if let Some(control_sender) = self.control_sender.take() {
+            if control_sender.send(ServiceWorkerControlMsg::Exit).is_err() {
+                warn!("Failed to send exit message to service worker scope.");
+            }
+        }
+
+        if let Some(closing) = self.closing.take() {
+            closing.store(true, Ordering::SeqCst);
+        }
+        if let Some(context) = self.context.take() {
+            context.request_interrupt_callback();
+        }
+
+        // TODO: Step 1, 2 and 3.
+        if let Some(join_handle) = self.join_handle.take() {
+            if join_handle.join().is_err() {
+                warn!("Failed to join on service worker thread.");
+            }
+        }
     }
 
     /// <https://w3c.github.io/ServiceWorker/#get-newest-worker>
@@ -299,8 +294,11 @@ impl ServiceWorkerManager {
 
     fn handle_message_from_constellation(&mut self, msg: ServiceWorkerMsg) -> bool {
         match msg {
-            ServiceWorkerMsg::Timeout(_scope) => {
-                // TODO: https://w3c.github.io/ServiceWorker/#terminate-service-worker
+            ServiceWorkerMsg::Timeout(scope) => {
+                // <https://w3c.github.io/ServiceWorker/#terminate-service-worker>
+                if let Some(registration) = self.registrations.get_mut(&scope) {
+                    registration.terminate_worker();
+                }
             },
             ServiceWorkerMsg::ForwardDOMMessage(msg, scope_url) => {
                 if let Some(registration) = self.registrations.get_mut(&scope_url) {


### PR DESCRIPTION
Implemented `ServiceWorkerRegistration::terminate_worker` and used it in `Drop` and `ServiceWorkerMsg::Timeout` handling.
Added `timeout_receiver` to `WorkerEventLoopMethods` trait and updated `run_worker_event_loop` to select on it.
Updated `ServiceWorkerGlobalScope` to send `ServiceWorkerMsg::Timeout` when the timeout port signals.
Updated `DedicatedWorkerGlobalScope` to provide a dummy timeout receiver.


---
*PR created automatically by Jules for task [15016551142767408983](https://jules.google.com/task/15016551142767408983) started by @RingCanary*