### PR TITLE
Implement entry settings object for Request constructor

### DIFF
--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -147,8 +147,7 @@ impl Request {
         }
 
         // Step 7. Let origin be this’s relevant settings object’s origin.
-        // TODO: `entry settings object` is not implemented yet.
-        let origin = base_url.origin();
+        let origin = GlobalScope::entry().origin().immutable().clone();
 
         // Step 8. Let traversableForUserPrompts be "client".
         let mut traversable_for_user_prompts = TraversableForUserPrompts::Client;


### PR DESCRIPTION
Implemented `entry settings object` for Request constructor in `components/script/dom/request.rs`. Replaced `base_url.origin()` with `GlobalScope::entry().origin().immutable().clone()` to resolve the TODO. Verify correctness via code analysis as local build environment has missing dependencies.

---
*PR created automatically by Jules for task [5213352494644200041](https://jules.google.com/task/5213352494644200041) started by @RingCanary*