### PR TITLE
Use config_dir for preferences on macOS

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -145,9 +145,7 @@ pub fn default_config_dir() -> Option<PathBuf> {
 
 #[cfg(target_os = "macos")]
 pub fn default_config_dir() -> Option<PathBuf> {
-    // FIXME: use `config_dir()` ($HOME/Library/Preferences)
-    // instead of `data_dir()` ($HOME/Library/Application Support) ?
-    let mut config_dir = ::dirs::data_dir().unwrap();
+    let mut config_dir = ::dirs::config_dir().unwrap();
     config_dir.push("Servo");
     Some(config_dir)
 }


### PR DESCRIPTION
Use `config_dir()` instead of `data_dir()` for preferences on macOS in `ports/servoshell/prefs.rs`.

---
*PR created automatically by Jules for task [970008124483739972](https://jules.google.com/task/970008124483739972) started by @RingCanary*