### PR TITLE
⚡ Bolt: Optimize HarfBuzz feature allocation

### DIFF
--- a/components/fonts/shapers/harfbuzz.rs
+++ b/components/fonts/shapers/harfbuzz.rs
@@ -27,6 +27,7 @@ use harfbuzz_sys::{
 };
 use num_traits::Zero;
 use read_fonts::types::Tag;
+use smallvec::SmallVec;
 
 use super::{HarfBuzzShapedGlyphData, ShapedGlyphEntry, unicode_script_to_iso15924_tag};
 use crate::platform::font::FontTable;
@@ -233,7 +234,7 @@ impl Shaper {
                 text.len() as c_int,
             );
 
-            let mut features = Vec::new();
+            let mut features: SmallVec<[hb_feature_t; 2]> = SmallVec::new();
             if options
                 .flags
                 .contains(ShapingFlags::IGNORE_LIGATURES_SHAPING_FLAG)


### PR DESCRIPTION
⚡ Bolt: Use SmallVec for HarfBuzz features

💡 What: Replaced `Vec` with `SmallVec` in `harfbuzz.rs`.
🎯 Why: Avoids heap allocation in a hot path (text shaping). The vector is small (max 2 items) and short-lived.
📊 Impact: Zero heap allocation for feature list in text shaping.
🔬 Measurement: Verified with `cargo check -p fonts` and `cargo test -p fonts`.

---
*PR created automatically by Jules for task [14853386833162847611](https://jules.google.com/task/14853386833162847611) started by @RingCanary*