### PR TITLE
⚡ Bolt: Optimize elements_from_point with Vec::with_capacity

### DIFF
--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -207,16 +207,14 @@ impl DocumentOrShadowRoot {
         let nodes = self
             .window
             .elements_from_point_query(LayoutPoint::new(x, y), ElementsFromPointFlags::FindAll);
-        let mut elements: Vec<DomRoot<Element>> = nodes
-            .iter()
-            .flat_map(|result| {
-                // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
-                // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
-                let address = UntrustedNodeAddress(result.node.0 as *const c_void);
-                let node = unsafe { node::from_untrusted_node_address(address) };
-                DomRoot::downcast::<Element>(node)
-            })
-            .collect();
+        let mut elements = Vec::with_capacity(nodes.len());
+        elements.extend(nodes.iter().flat_map(|result| {
+            // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
+            // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
+            let address = UntrustedNodeAddress(result.node.0 as *const c_void);
+            let node = unsafe { node::from_untrusted_node_address(address) };
+            DomRoot::downcast::<Element>(node)
+        }));
 
         // Step 4
         if let Some(root_element) = document_element {
@@ -336,8 +334,8 @@ impl DocumentOrShadowRoot {
     ) {
         debug!("Adding named element {:p}: {:p} id={}", self, element, id);
         assert!(
-            element.upcast::<Node>().is_in_a_document_tree() ||
-                element.upcast::<Node>().is_in_a_shadow_tree()
+            element.upcast::<Node>().is_in_a_document_tree()
+                || element.upcast::<Node>().is_in_a_shadow_tree()
         );
         assert!(!id.is_empty());
         let mut id_map = id_map.borrow_mut();

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -402,12 +402,16 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     fn ElementsFromPoint(&self, x: Finite<f64>, y: Finite<f64>) -> Vec<DomRoot<Element>> {
         // Return the result of running the retargeting algorithm with context object
         // and the original result as input
-        let mut elements = Vec::new();
-        for e in self
-            .document_or_shadow_root
-            .elements_from_point(x, y, None, self.document.has_browsing_context())
-            .iter()
-        {
+        let retrieved_elements = self.document_or_shadow_root.elements_from_point(
+            x,
+            y,
+            None,
+            self.document.has_browsing_context(),
+        );
+
+        let mut elements = Vec::with_capacity(retrieved_elements.len());
+
+        for e in retrieved_elements.iter() {
             let retargeted_node = e.upcast::<EventTarget>().retarget(self.upcast());
             if let Some(element) = retargeted_node.downcast::<Element>().map(DomRoot::from_ref) {
                 elements.push(element);


### PR DESCRIPTION
This PR optimizes the `elements_from_point` and `ElementsFromPoint` methods in `components/script/dom/documentorshadowroot.rs` and `components/script/dom/shadowroot.rs` respectively. 

By pre-allocating vectors with `Vec::with_capacity` using the known size of the source collection (or query results), we avoid unnecessary reallocations during the construction of the result vector. This is particularly beneficial for hit-testing operations which can be frequent during user interaction.

The changes involve:
1. Using `Vec::with_capacity(nodes.len())` instead of `.collect()` on a `flat_map` iterator in `DocumentOrShadowRoot`.
2. Breaking the iterator chain in `ShadowRoot` to capture the intermediate result's length for pre-allocation.

---
*PR created automatically by Jules for task [13122151547143066970](https://jules.google.com/task/13122151547143066970) started by @RingCanary*