### PR TITLE
⚡ Bolt: Optimize elements_from_point allocation

### DIFF
--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -207,16 +207,14 @@ impl DocumentOrShadowRoot {
         let nodes = self
             .window
             .elements_from_point_query(LayoutPoint::new(x, y), ElementsFromPointFlags::FindAll);
-        let mut elements: Vec<DomRoot<Element>> = nodes
-            .iter()
-            .flat_map(|result| {
-                // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
-                // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
-                let address = UntrustedNodeAddress(result.node.0 as *const c_void);
-                let node = unsafe { node::from_untrusted_node_address(address) };
-                DomRoot::downcast::<Element>(node)
-            })
-            .collect();
+        let mut elements = Vec::with_capacity(nodes.len());
+        elements.extend(nodes.iter().filter_map(|result| {
+            // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
+            // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
+            let address = UntrustedNodeAddress(result.node.0 as *const c_void);
+            let node = unsafe { node::from_untrusted_node_address(address) };
+            DomRoot::downcast::<Element>(node)
+        }));
 
         // Step 4
         if let Some(root_element) = document_element {

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -402,12 +402,11 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     fn ElementsFromPoint(&self, x: Finite<f64>, y: Finite<f64>) -> Vec<DomRoot<Element>> {
         // Return the result of running the retargeting algorithm with context object
         // and the original result as input
-        let mut elements = Vec::new();
-        for e in self
+        let hit_elements = self
             .document_or_shadow_root
-            .elements_from_point(x, y, None, self.document.has_browsing_context())
-            .iter()
-        {
+            .elements_from_point(x, y, None, self.document.has_browsing_context());
+        let mut elements = Vec::with_capacity(hit_elements.len());
+        for e in hit_elements.iter() {
             let retargeted_node = e.upcast::<EventTarget>().retarget(self.upcast());
             if let Some(element) = retargeted_node.downcast::<Element>().map(DomRoot::from_ref) {
                 elements.push(element);


### PR DESCRIPTION
💡 What: Optimized vector allocation in `DocumentOrShadowRoot::elements_from_point` and `ShadowRoot::ElementsFromPoint` by using `Vec::with_capacity` and avoiding unnecessary reallocations.

🎯 Why: To reduce allocation churn in hit-testing logic, which is a potential hot path for user interaction (pointer events).

📊 Impact: Reduces reallocations. `ElementsFromPoint` now performs a single allocation for the result vector based on the known number of hit test results.

🔬 Measurement: Verified via manual code inspection as local build environment lacks `llvm-objdump`.

---
*PR created automatically by Jules for task [15317571758340242803](https://jules.google.com/task/15317571758340242803) started by @RingCanary*