### PR TITLE
⚡ Bolt: Optimize insert_pre_order with binary search

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -4568,6 +4568,40 @@ pub(crate) trait VecPreOrderInsertionHelper<T> {
     fn insert_pre_order(&mut self, elem: &T, tree_root: &Node);
 }
 
+/// Helper to efficiently check if `a` is before `b` among siblings without full index calculation.
+/// Assumes `a` and `b` share the same parent.
+fn is_before_sibling(a: &Node, b: &Node) -> bool {
+    debug_assert!(a.GetParentNode() == b.GetParentNode());
+    if a == b {
+        return false; // strictly before
+    }
+
+    // Interleaved walk to find which comes first.
+    let mut next_a = a.GetNextSibling();
+    let mut next_b = b.GetNextSibling();
+
+    loop {
+        if next_a.is_none() && next_b.is_none() {
+            // Should not be reachable if a != b and both are children of same parent
+            return false;
+        }
+
+        if let Some(ref na) = next_a {
+            if &**na == b {
+                return true; // a found b, so a is before b
+            }
+            next_a = na.GetNextSibling();
+        }
+
+        if let Some(ref nb) = next_b {
+            if &**nb == a {
+                return false; // b found a, so b is before a (a is not before b)
+            }
+            next_b = nb.GetNextSibling();
+        }
+    }
+}
+
 impl<T> VecPreOrderInsertionHelper<T> for Vec<Dom<T>>
 where
     T: DerivedFrom<Node> + DomObject,
@@ -4577,27 +4611,42 @@ where
     /// * any time an element is removed from the tree root, it is also removed from this array
     /// * any time an element is moved within the tree, it is removed from this array and re-inserted
     ///
-    /// Under these assumptions, an element's tree-order position in this array can be determined by
-    /// performing a [preorder traversal](https://dom.spec.whatwg.org/#concept-tree-order) of the tree root's children,
-    /// and increasing the destination index in the array every time a node in the array is encountered during
-    /// the traversal.
-    fn insert_pre_order(&mut self, elem: &T, tree_root: &Node) {
+    /// Under these assumptions, we can use the relative document position of nodes to determine
+    /// the correct insertion point, which is significantly faster than traversing the entire tree.
+    fn insert_pre_order(&mut self, elem: &T, _tree_root: &Node) {
         if self.is_empty() {
             self.push(Dom::from_ref(elem));
             return;
         }
 
         let elem_node = elem.upcast::<Node>();
-        let mut head: usize = 0;
-        for node in tree_root.traverse_preorder(ShadowIncluding::No) {
-            let head_node = DomRoot::upcast::<Node>(DomRoot::from_ref(&*self[head]));
-            if head_node == node {
-                head += 1;
-            }
-            if elem_node == &*node || head == self.len() {
-                break;
-            }
+
+        // Optimization: Check if we are appending at the end (very common case during parsing/construction).
+        // We handle the sibling case specifically because it's fast and common.
+        let last_node = self.last().map(|d| d.upcast::<Node>()).unwrap();
+        let is_last_before = if last_node.GetParentNode() == elem_node.GetParentNode() {
+            is_before_sibling(last_node, elem_node)
+        } else {
+            last_node.is_before(elem_node)
+        };
+
+        if is_last_before {
+            self.push(Dom::from_ref(elem));
+            return;
         }
-        self.insert(head, Dom::from_ref(elem));
+
+        // Use binary search to find the insertion point.
+        let idx = self.partition_point(|existing| {
+            let existing_node = existing.upcast::<Node>();
+
+            // Check for sibling optimization (same parent)
+            if existing_node.GetParentNode() == elem_node.GetParentNode() {
+                is_before_sibling(existing_node, elem_node)
+            } else {
+                existing_node.is_before(elem_node)
+            }
+        });
+
+        self.insert(idx, Dom::from_ref(elem));
     }
 }


### PR DESCRIPTION
This PR optimizes `VecPreOrderInsertionHelper::insert_pre_order` in `components/script/dom/node.rs`. The original implementation performed a full preorder traversal of the DOM subtree to find the insertion point, which is O(N) where N is the number of nodes in the subtree. This was particularly inefficient for large forms or shadow roots.

The new implementation:
1.  **Binary Search**: Uses `slice::partition_point` to find the insertion index in O(log M * CostOfCompare), where M is the number of elements in the vector.
2.  **Append Optimization**: Checks if the new element comes after the last element in the vector. This makes the common case of sequential construction (e.g., during parsing) O(1).
3.  **Optimized Sibling Check**: Introduces `is_before_sibling` for nodes sharing the same parent. This helper performs an interleaved walk to determine order in O(distance) time, avoiding the O(index) cost of `CompareDocumentPosition` for siblings in flat trees.
4.  **Fallback**: Uses `Node::is_before` (which relies on `CompareDocumentPosition`) for non-sibling nodes, leveraging its efficiency for deep trees (O(depth)).

Performance analysis:
- **Sequential Append**: O(1) (was O(N)).
- **Random Insertion (Flat Tree)**: O(log M * distance) (was O(N)).
- **Random Insertion (Deep Tree)**: O(log M * depth) (was O(N)).

This change is purely internal to the `VecPreOrderInsertionHelper` trait and preserves the sorted invariant of the vector.

---
*PR created automatically by Jules for task [17740044896265408765](https://jules.google.com/task/17740044896265408765) started by @RingCanary*