### PR TITLE
⚡ Bolt: Optimize timer queue operations and reduce borrow overhead

### DIFF
--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -51,7 +51,7 @@ type CompletionStep = Box<dyn FnOnce(&GlobalScope, CanGc) + 'static>;
 /// OrderingIdentifier per spec ("orderingIdentifier")
 type OrderingIdentifier = DOMString;
 
-#[derive(JSTraceable, MallocSizeOf)]
+#[derive(Clone, Copy, JSTraceable, MallocSizeOf)]
 struct OrderingEntry {
     milliseconds: u64,
     start_seq: u64,
@@ -230,7 +230,6 @@ impl OneshotTimers {
         milliseconds: u64,
     ) {
         let mut map = self.runsteps_queues.borrow_mut();
-        let q = map.entry(ordering_id.clone()).or_default();
 
         let seq = {
             let cur = self.runsteps_start_seq.get();
@@ -244,12 +243,22 @@ impl OneshotTimers {
             handle,
         };
 
+        if let Some(q) = map.get_mut(ordering_id) {
+            Self::insert_into_runsteps_queue(q, key);
+        } else {
+            let mut q = Vec::new();
+            Self::insert_into_runsteps_queue(&mut q, key);
+            map.insert(ordering_id.clone(), q);
+        }
+    }
+
+    fn insert_into_runsteps_queue(q: &mut Vec<OrderingEntry>, key: OrderingEntry) {
         let idx = q
             .binary_search_by(|ordering_entry| {
-                match ordering_entry.milliseconds.cmp(&milliseconds) {
+                match ordering_entry.milliseconds.cmp(&key.milliseconds) {
                     Ordering::Less => Ordering::Less,
                     Ordering::Greater => Ordering::Greater,
-                    Ordering::Equal => ordering_entry.start_seq.cmp(&seq),
+                    Ordering::Equal => ordering_entry.start_seq.cmp(&key.start_seq),
                 }
             })
             .unwrap_or_else(|i| i);
@@ -342,14 +351,20 @@ impl OneshotTimers {
         // that were installed during fire of another timer
         let mut timers_to_run = Vec::new();
 
-        loop {
+        {
             let mut timers = self.timers.borrow_mut();
+            loop {
+                let should_pop = match timers.back() {
+                    Some(timer) => timer.scheduled_for <= base_time,
+                    None => false,
+                };
 
-            if timers.is_empty() || timers.back().unwrap().scheduled_for > base_time {
-                break;
+                if should_pop {
+                    timers_to_run.push(timers.pop_back().unwrap());
+                } else {
+                    break;
+                }
             }
-
-            timers_to_run.push(timers.pop_back().unwrap());
         }
 
         for timer in timers_to_run {


### PR DESCRIPTION
This PR optimizes `components/script/timers.rs` by reducing unnecessary allocations and runtime overhead.

1.  **Avoid Unnecessary Cloning:** In `runsteps_enqueue_sorted`, the `ordering_id` (a `DOMString` / `String`) was being cloned unconditionally to use `map.entry()`. I refactored this to use `map.get_mut()` first, which takes a reference, avoiding the clone if the key exists.
2.  **Derive Copy:** `OrderingEntry` is now `Copy`, making it cheaper to pass around and simplifying the insertion logic.
3.  **RefCell Hoisting:** The `fire_timer` method was repeatedly borrowing `self.timers` (a `DomRefCell`) inside a loop. I hoisted the `borrow_mut` call outside the loop to perform a single borrow, reducing runtime overhead. I handled the borrow checker constraints by scoping the `back()` (immutable) access before calling `pop_back()` (mutable).

These changes improve the efficiency of timer management, particularly for "Run Steps After A Timeout" logic and general timer firing.

---
*PR created automatically by Jules for task [1955088416833317610](https://jules.google.com/task/1955088416833317610) started by @RingCanary*