### PR TITLE
⚡ Bolt: Optimize ElementsFromPoint vector allocation

### DIFF
--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -207,16 +207,16 @@ impl DocumentOrShadowRoot {
         let nodes = self
             .window
             .elements_from_point_query(LayoutPoint::new(x, y), ElementsFromPointFlags::FindAll);
-        let mut elements: Vec<DomRoot<Element>> = nodes
-            .iter()
-            .flat_map(|result| {
-                // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
-                // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
-                let address = UntrustedNodeAddress(result.node.0 as *const c_void);
-                let node = unsafe { node::from_untrusted_node_address(address) };
-                DomRoot::downcast::<Element>(node)
-            })
-            .collect();
+        let mut elements = Vec::with_capacity(nodes.len());
+        for result in &nodes {
+            // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
+            // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
+            let address = UntrustedNodeAddress(result.node.0 as *const c_void);
+            let node = unsafe { node::from_untrusted_node_address(address) };
+            if let Some(element) = DomRoot::downcast::<Element>(node) {
+                elements.push(element);
+            }
+        }
 
         // Step 4
         if let Some(root_element) = document_element {

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -402,12 +402,11 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     fn ElementsFromPoint(&self, x: Finite<f64>, y: Finite<f64>) -> Vec<DomRoot<Element>> {
         // Return the result of running the retargeting algorithm with context object
         // and the original result as input
-        let mut elements = Vec::new();
-        for e in self
+        let hit_elements = self
             .document_or_shadow_root
-            .elements_from_point(x, y, None, self.document.has_browsing_context())
-            .iter()
-        {
+            .elements_from_point(x, y, None, self.document.has_browsing_context());
+        let mut elements = Vec::with_capacity(hit_elements.len());
+        for e in hit_elements.iter() {
             let retargeted_node = e.upcast::<EventTarget>().retarget(self.upcast());
             if let Some(element) = retargeted_node.downcast::<Element>().map(DomRoot::from_ref) {
                 elements.push(element);


### PR DESCRIPTION
💡 What: Optimized vector allocation in `ElementsFromPoint` methods in `components/script/dom/documentorshadowroot.rs` and `components/script/dom/shadowroot.rs`.
🎯 Why: `flat_map` followed by `collect` (and `Vec::new()` followed by `push` in a loop) can cause multiple reallocations as the vector grows. Since the result vector size is bounded by the hit-testing result, we can pre-allocate it using `Vec::with_capacity`.
📊 Impact: Reduces potential reallocations during hit-testing operations.
🔬 Measurement: Verified manually that the logic is preserved and types are correct. `cargo check` fails due to environment issues (missing `llvm-objdump`) but logic is sound and matches existing patterns.

---
*PR created automatically by Jules for task [14574538033553588247](https://jules.google.com/task/14574538033553588247) started by @RingCanary*