### PR TITLE
⚡ Bolt: Optimize `elements_from_point` allocation

### DIFF
--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -195,28 +195,31 @@ impl DocumentOrShadowRoot {
         let viewport = self.window.viewport_details().size;
 
         if !has_browsing_context {
-            return vec![];
+            return Vec::new();
         }
 
         // Step 2
         if x < 0.0 || y < 0.0 || x > viewport.width || y > viewport.height {
-            return vec![];
+            return Vec::new();
         }
 
         // Step 1 and Step 3
         let nodes = self
             .window
             .elements_from_point_query(LayoutPoint::new(x, y), ElementsFromPointFlags::FindAll);
-        let mut elements: Vec<DomRoot<Element>> = nodes
-            .iter()
-            .flat_map(|result| {
-                // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
-                // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
-                let address = UntrustedNodeAddress(result.node.0 as *const c_void);
-                let node = unsafe { node::from_untrusted_node_address(address) };
-                DomRoot::downcast::<Element>(node)
-            })
-            .collect();
+
+        // Pre-allocate assuming all nodes are elements, plus one for potential root element.
+        let mut elements: Vec<DomRoot<Element>> = Vec::with_capacity(nodes.len() + 1);
+
+        for result in nodes {
+            // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
+            // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
+            let address = UntrustedNodeAddress(result.node.0 as *const c_void);
+            let node = unsafe { node::from_untrusted_node_address(address) };
+            if let Some(element) = DomRoot::downcast::<Element>(node) {
+                elements.push(element);
+            }
+        }
 
         // Step 4
         if let Some(root_element) = document_element {

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -402,12 +402,12 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     fn ElementsFromPoint(&self, x: Finite<f64>, y: Finite<f64>) -> Vec<DomRoot<Element>> {
         // Return the result of running the retargeting algorithm with context object
         // and the original result as input
-        let mut elements = Vec::new();
-        for e in self
+        let retrieved_elements = self
             .document_or_shadow_root
-            .elements_from_point(x, y, None, self.document.has_browsing_context())
-            .iter()
-        {
+            .elements_from_point(x, y, None, self.document.has_browsing_context());
+
+        let mut elements = Vec::with_capacity(retrieved_elements.len());
+        for e in retrieved_elements {
             let retargeted_node = e.upcast::<EventTarget>().retarget(self.upcast());
             if let Some(element) = retargeted_node.downcast::<Element>().map(DomRoot::from_ref) {
                 elements.push(element);


### PR DESCRIPTION
💡 **What**: Optimized `elements_from_point` in `DocumentOrShadowRoot` and `ShadowRoot` to pre-allocate result vectors.
🎯 **Why**: The original implementation used `flat_map().collect()` which cannot predict the exact size, leading to potential reallocations. `ShadowRoot::ElementsFromPoint` also allocated a new vector without capacity reservation.
📊 **Impact**: Reduces allocation overhead in hit-testing logic (hit testing is a common operation during pointer events).
🔬 **Measurement**: Verified by inspection. Pre-allocation uses known upper bounds (`nodes.len() + 1`).

---
*PR created automatically by Jules for task [13396847630238144400](https://jules.google.com/task/13396847630238144400) started by @RingCanary*