### PR TITLE
⚡ Bolt: Optimize IFrameCollection and Window::Length

### DIFF
--- a/components/script/document_collection.rs
+++ b/components/script/document_collection.rs
@@ -140,12 +140,16 @@ impl DocumentTree {
         let mut tree = DocumentTree::default();
         tree.tree.reserve(documents.map.len());
         for (id, document) in documents.iter() {
-            let children: Vec<PipelineId> = document
-                .iframes()
-                .iter()
-                .filter_map(|iframe| iframe.pipeline_id())
-                .filter(|iframe_pipeline_id| documents.find_document(*iframe_pipeline_id).is_some())
-                .collect();
+            let iframes = document.iframes();
+            let mut children: Vec<PipelineId> = Vec::with_capacity(iframes.len());
+            children.extend(
+                iframes
+                    .iter()
+                    .filter_map(|iframe| iframe.pipeline_id())
+                    .filter(|iframe_pipeline_id| {
+                        documents.find_document(*iframe_pipeline_id).is_some()
+                    }),
+            );
             for child in &children {
                 tree.tree.entry(*child).or_default().parent = Some(id);
             }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1615,7 +1615,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     /// <https://html.spec.whatwg.org/multipage/#accessing-other-browsing-contexts>
     fn Length(&self) -> u32 {
-        self.Document().iframes().iter().count() as u32
+        self.Document().iframes().len() as u32
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-parent>

--- a/components/script/iframe_collection.rs
+++ b/components/script/iframe_collection.rs
@@ -46,6 +46,14 @@ impl IFrameCollection {
         self.invalid = true;
     }
 
+    pub(crate) fn len(&self) -> usize {
+        self.iframes.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.iframes.is_empty()
+    }
+
     /// Validate that the collection is up-to-date with the given [`Document`]. If it isn't up-to-date
     /// rebuild it.
     pub(crate) fn validate(&mut self, document: &Document) {


### PR DESCRIPTION
Implemented `len()` and `is_empty()` for `IFrameCollection` to allow O(1) access to the number of iframes.
Optimized `Window::Length()` to use `len()` instead of iterating and counting (O(N) -> O(1)).
Optimized `DocumentTree::new` to pre-allocate the children vector using `Vec::with_capacity` based on the number of iframes, reducing reallocations.

💡 What:
- Added `len()` and `is_empty()` to `IFrameCollection`.
- Updated `Window::Length()` to use `self.Document().iframes().len()`.
- Updated `DocumentTree::new` to pre-allocate `children` vector.

🎯 Why:
- `Window::Length` was O(N) due to `iter().count()`.
- `DocumentTree::new` was collecting into a `Vec` without pre-allocation, causing potential reallocations.

📊 Impact:
- `Window::Length` is now O(1).
- `DocumentTree::new` avoids vector reallocations.

🔬 Measurement:
- Verified logic by code review and compilation checks (formatting).
- `cargo test` failed due to missing `llvm-objdump` in the environment, but changes are logically sound and safe.

---
*PR created automatically by Jules for task [12495629302520156995](https://jules.google.com/task/12495629302520156995) started by @RingCanary*