### PR TITLE
⚡ Bolt: Pre-allocate Vec in ElementsFromPoint

### DIFF
--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -207,16 +207,14 @@ impl DocumentOrShadowRoot {
         let nodes = self
             .window
             .elements_from_point_query(LayoutPoint::new(x, y), ElementsFromPointFlags::FindAll);
-        let mut elements: Vec<DomRoot<Element>> = nodes
-            .iter()
-            .flat_map(|result| {
-                // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
-                // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
-                let address = UntrustedNodeAddress(result.node.0 as *const c_void);
-                let node = unsafe { node::from_untrusted_node_address(address) };
-                DomRoot::downcast::<Element>(node)
-            })
-            .collect();
+        let mut elements = Vec::with_capacity(nodes.len() + 1);
+        elements.extend(nodes.iter().flat_map(|result| {
+            // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
+            // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
+            let address = UntrustedNodeAddress(result.node.0 as *const c_void);
+            let node = unsafe { node::from_untrusted_node_address(address) };
+            DomRoot::downcast::<Element>(node)
+        }));
 
         // Step 4
         if let Some(root_element) = document_element {

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -402,12 +402,13 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     fn ElementsFromPoint(&self, x: Finite<f64>, y: Finite<f64>) -> Vec<DomRoot<Element>> {
         // Return the result of running the retargeting algorithm with context object
         // and the original result as input
-        let mut elements = Vec::new();
-        for e in self
+        let retrieved = self
             .document_or_shadow_root
-            .elements_from_point(x, y, None, self.document.has_browsing_context())
-            .iter()
-        {
+            .elements_from_point(x, y, None, self.document.has_browsing_context());
+
+        let mut elements = Vec::with_capacity(retrieved.len());
+
+        for e in retrieved.iter() {
             let retargeted_node = e.upcast::<EventTarget>().retarget(self.upcast());
             if let Some(element) = retargeted_node.downcast::<Element>().map(DomRoot::from_ref) {
                 elements.push(element);


### PR DESCRIPTION
⚡ Bolt Optimization: Pre-allocate vectors in `ElementsFromPoint`

💡 **What:**
- In `components/script/dom/documentorshadowroot.rs`: Changed `collect()` to `Vec::with_capacity(...)` + `extend(...)` for `elements_from_point`. Capacity is `nodes.len() + 1`.
- In `components/script/dom/shadowroot.rs`: Changed `Vec::new()` to `Vec::with_capacity(retrieved.len())` for `ElementsFromPoint`.

🎯 **Why:**
- `ElementsFromPoint` involves iterating over layout hit-test results and constructing a list of DOM elements.
- The default `Vec::new()` or `collect()` on `flat_map` (which yields 0 or 1 item) often results in incremental resizing of the vector (reallocations).
- Since we have the list of hit-test results (`nodes` or `retrieved`), we know the upper bound of the result size.
- Pre-allocating avoids memory churn in this hot path (hit testing is frequent during user interaction).

📊 **Impact:**
- Reduces allocation overhead for `elementsFromPoint` API calls.
- Transforms O(log N) allocations into O(1) allocation per call.

🔬 **Measurement:**
- Verified by code inspection.
- Benchmark: N/A (requires full build environment).


---
*PR created automatically by Jules for task [3811119273848797940](https://jules.google.com/task/3811119273848797940) started by @RingCanary*