### PR TITLE
⚡ Bolt: Optimize allocation in elements_from_point

### DIFF
--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -207,16 +207,16 @@ impl DocumentOrShadowRoot {
         let nodes = self
             .window
             .elements_from_point_query(LayoutPoint::new(x, y), ElementsFromPointFlags::FindAll);
-        let mut elements: Vec<DomRoot<Element>> = nodes
-            .iter()
-            .flat_map(|result| {
-                // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
-                // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
-                let address = UntrustedNodeAddress(result.node.0 as *const c_void);
-                let node = unsafe { node::from_untrusted_node_address(address) };
-                DomRoot::downcast::<Element>(node)
-            })
-            .collect();
+        let mut elements = Vec::with_capacity(nodes.len() + 1);
+        for result in nodes {
+            // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
+            // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
+            let address = UntrustedNodeAddress(result.node.0 as *const c_void);
+            let node = unsafe { node::from_untrusted_node_address(address) };
+            if let Some(element) = DomRoot::downcast::<Element>(node) {
+                elements.push(element);
+            }
+        }
 
         // Step 4
         if let Some(root_element) = document_element {

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -402,12 +402,14 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     fn ElementsFromPoint(&self, x: Finite<f64>, y: Finite<f64>) -> Vec<DomRoot<Element>> {
         // Return the result of running the retargeting algorithm with context object
         // and the original result as input
-        let mut elements = Vec::new();
-        for e in self
-            .document_or_shadow_root
-            .elements_from_point(x, y, None, self.document.has_browsing_context())
-            .iter()
-        {
+        let retrieved = self.document_or_shadow_root.elements_from_point(
+            x,
+            y,
+            None,
+            self.document.has_browsing_context(),
+        );
+        let mut elements = Vec::with_capacity(retrieved.len());
+        for e in retrieved.iter() {
             let retargeted_node = e.upcast::<EventTarget>().retarget(self.upcast());
             if let Some(element) = retargeted_node.downcast::<Element>().map(DomRoot::from_ref) {
                 elements.push(element);


### PR DESCRIPTION
💡 What: The optimization implemented.
Replaced `collect()` on `flat_map` iterator with explicit loop and `Vec::with_capacity` in `components/script/dom/documentorshadowroot.rs`.
Pre-allocated vector in `components/script/dom/shadowroot.rs` before populating it with retargeted elements.

🎯 Why: The performance problem it solves.
Reduces allocation churn by avoiding repeated resizing of vectors when the upper bound size is known. `flat_map` iterators often have poor size hints, leading `collect()` to start with a small capacity and reallocate multiple times. `elements_from_point` is part of hit-testing which can be hot during user interaction.

📊 Impact: Expected performance improvement.
Reduces allocation overhead. The size of the allocation is now exact (or +1) avoiding reallocations.

🔬 Measurement: How to verify the improvement.
Code inspection confirms `Vec::with_capacity` is used with the source vector length. Verified logic preserves correctness including `unsafe` blocks and filtering.

---
*PR created automatically by Jules for task [654682859212500762](https://jules.google.com/task/654682859212500762) started by @RingCanary*