### PR TITLE
⚡ Bolt: Optimize elements_from_point allocation

### DIFF
--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -207,16 +207,19 @@ impl DocumentOrShadowRoot {
         let nodes = self
             .window
             .elements_from_point_query(LayoutPoint::new(x, y), ElementsFromPointFlags::FindAll);
-        let mut elements: Vec<DomRoot<Element>> = nodes
-            .iter()
-            .flat_map(|result| {
-                // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
-                // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
-                let address = UntrustedNodeAddress(result.node.0 as *const c_void);
-                let node = unsafe { node::from_untrusted_node_address(address) };
-                DomRoot::downcast::<Element>(node)
-            })
-            .collect();
+
+        // Pre-allocate the vector with capacity to avoid reallocations.
+        // We add 1 for the potential root_element in Step 4.
+        let mut elements = Vec::with_capacity(nodes.len() + 1);
+        for result in &nodes {
+            // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
+            // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
+            let address = UntrustedNodeAddress(result.node.0 as *const c_void);
+            let node = unsafe { node::from_untrusted_node_address(address) };
+            if let Some(element) = DomRoot::downcast::<Element>(node) {
+                elements.push(element);
+            }
+        }
 
         // Step 4
         if let Some(root_element) = document_element {
@@ -336,8 +339,8 @@ impl DocumentOrShadowRoot {
     ) {
         debug!("Adding named element {:p}: {:p} id={}", self, element, id);
         assert!(
-            element.upcast::<Node>().is_in_a_document_tree() ||
-                element.upcast::<Node>().is_in_a_shadow_tree()
+            element.upcast::<Node>().is_in_a_document_tree()
+                || element.upcast::<Node>().is_in_a_shadow_tree()
         );
         assert!(!id.is_empty());
         let mut id_map = id_map.borrow_mut();

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -402,12 +402,15 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     fn ElementsFromPoint(&self, x: Finite<f64>, y: Finite<f64>) -> Vec<DomRoot<Element>> {
         // Return the result of running the retargeting algorithm with context object
         // and the original result as input
-        let mut elements = Vec::new();
-        for e in self
-            .document_or_shadow_root
-            .elements_from_point(x, y, None, self.document.has_browsing_context())
-            .iter()
-        {
+        let retrieved = self.document_or_shadow_root.elements_from_point(
+            x,
+            y,
+            None,
+            self.document.has_browsing_context(),
+        );
+
+        let mut elements = Vec::with_capacity(retrieved.len());
+        for e in retrieved.iter() {
             let retargeted_node = e.upcast::<EventTarget>().retarget(self.upcast());
             if let Some(element) = retargeted_node.downcast::<Element>().map(DomRoot::from_ref) {
                 elements.push(element);


### PR DESCRIPTION
💡 What: Optimized `elements_from_point` in `documentorshadowroot.rs` and `ElementsFromPoint` in `shadowroot.rs` to use `Vec::with_capacity` based on the known number of hit test results.

🎯 Why: These methods are used during hit testing (e.g., mouse events, drag and drop). `collect()` on `flat_map` iterators often fails to estimate the correct size, leading to multiple reallocations. Pre-allocating the vector reduces memory churn and improves performance.

📊 Impact: Reduces `Vec` reallocations during hit testing. The size is known exactly (`nodes.len()` or `retrieved.len()`), so we can allocate exactly once.

🔬 Measurement:
- Verified code logic manually as `cargo check` fails due to environment issues (`llvm-objdump` missing).
- The optimization is a standard Rust pattern for known-size collections.

---
*PR created automatically by Jules for task [9639342352297560723](https://jules.google.com/task/9639342352297560723) started by @RingCanary*