### PR TITLE
⚡ Bolt: Optimize vector allocation in `elements_from_point`

### DIFF
--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -207,16 +207,17 @@ impl DocumentOrShadowRoot {
         let nodes = self
             .window
             .elements_from_point_query(LayoutPoint::new(x, y), ElementsFromPointFlags::FindAll);
-        let mut elements: Vec<DomRoot<Element>> = nodes
-            .iter()
-            .flat_map(|result| {
-                // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
-                // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
-                let address = UntrustedNodeAddress(result.node.0 as *const c_void);
-                let node = unsafe { node::from_untrusted_node_address(address) };
-                DomRoot::downcast::<Element>(node)
-            })
-            .collect();
+
+        let mut elements = Vec::with_capacity(nodes.len() + 1);
+        for result in &nodes {
+            // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
+            // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
+            let address = UntrustedNodeAddress(result.node.0 as *const c_void);
+            let node = unsafe { node::from_untrusted_node_address(address) };
+            if let Some(element) = DomRoot::downcast::<Element>(node) {
+                elements.push(element);
+            }
+        }
 
         // Step 4
         if let Some(root_element) = document_element {

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -402,12 +402,13 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     fn ElementsFromPoint(&self, x: Finite<f64>, y: Finite<f64>) -> Vec<DomRoot<Element>> {
         // Return the result of running the retargeting algorithm with context object
         // and the original result as input
-        let mut elements = Vec::new();
-        for e in self
+        let retrieved_elements = self
             .document_or_shadow_root
-            .elements_from_point(x, y, None, self.document.has_browsing_context())
-            .iter()
-        {
+            .elements_from_point(x, y, None, self.document.has_browsing_context());
+
+        let mut elements = Vec::with_capacity(retrieved_elements.len());
+
+        for e in retrieved_elements.iter() {
             let retargeted_node = e.upcast::<EventTarget>().retarget(self.upcast());
             if let Some(element) = retargeted_node.downcast::<Element>().map(DomRoot::from_ref) {
                 elements.push(element);


### PR DESCRIPTION
⚡ Bolt: Optimized vector allocation in hit-testing

💡 What:
- Replaced `nodes.iter().flat_map(...).collect()` with a manual loop and `Vec::with_capacity(nodes.len() + 1)` in `documentorshadowroot.rs`.
- Added `Vec::with_capacity(retrieved.len())` in `shadowroot.rs` before populating the results.

🎯 Why:
- Hit-testing (`elements_from_point`) can return many elements. Growing vectors dynamically is expensive due to reallocations.
- Knowing the upper bound of the result allows us to allocate exactly once.

📊 Impact:
- Reduces allocation churn in `elements_from_point`.
- O(1) allocation instead of O(log N) reallocations.

🔬 Measurement:
- Verified by code inspection and review. Compilation in this environment is limited due to missing `llvm-objdump`.

---
*PR created automatically by Jules for task [12542610454244972630](https://jules.google.com/task/12542610454244972630) started by @RingCanary*