### PR TITLE
⚡ Bolt: Optimize ElementsFromPoint allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-19 - Iterator Pre-allocation in ShadowRoot
+**Learning:** In Rust, `Vec::from_iter` (via `collect()`) fails to pre-allocate optimally when the iterator is a `FlatMap` or `FilterMap` due to vague size hints from the iterator. This causes unnecessary array resizes and memory allocations.
+**Action:** When mapping over items and filtering them (like `Result` filtering), and the upper bound is known (like in `elements_from_point`), replace `.collect()` with `Vec::with_capacity(known_upper_bound)` and iterate using a `for` loop, calling `elements.push()`. This prevents unexpected allocations.

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -207,16 +207,16 @@ impl DocumentOrShadowRoot {
         let nodes = self
             .window
             .elements_from_point_query(LayoutPoint::new(x, y), ElementsFromPointFlags::FindAll);
-        let mut elements: Vec<DomRoot<Element>> = nodes
-            .iter()
-            .flat_map(|result| {
-                // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
-                // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
-                let address = UntrustedNodeAddress(result.node.0 as *const c_void);
-                let node = unsafe { node::from_untrusted_node_address(address) };
-                DomRoot::downcast::<Element>(node)
-            })
-            .collect();
+        let mut elements: Vec<DomRoot<Element>> = Vec::with_capacity(nodes.len() + 1);
+        for result in nodes.iter() {
+            // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
+            // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
+            let address = UntrustedNodeAddress(result.node.0 as *const c_void);
+            let node = unsafe { node::from_untrusted_node_address(address) };
+            if let Some(element) = DomRoot::downcast::<Element>(node) {
+                elements.push(element);
+            }
+        }
 
         // Step 4
         if let Some(root_element) = document_element {
@@ -336,8 +336,8 @@ impl DocumentOrShadowRoot {
     ) {
         debug!("Adding named element {:p}: {:p} id={}", self, element, id);
         assert!(
-            element.upcast::<Node>().is_in_a_document_tree() ||
-                element.upcast::<Node>().is_in_a_shadow_tree()
+            element.upcast::<Node>().is_in_a_document_tree()
+                || element.upcast::<Node>().is_in_a_shadow_tree()
         );
         assert!(!id.is_empty());
         let mut id_map = id_map.borrow_mut();

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -402,12 +402,14 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     fn ElementsFromPoint(&self, x: Finite<f64>, y: Finite<f64>) -> Vec<DomRoot<Element>> {
         // Return the result of running the retargeting algorithm with context object
         // and the original result as input
-        let mut elements = Vec::new();
-        for e in self
-            .document_or_shadow_root
-            .elements_from_point(x, y, None, self.document.has_browsing_context())
-            .iter()
-        {
+        let results = self.document_or_shadow_root.elements_from_point(
+            x,
+            y,
+            None,
+            self.document.has_browsing_context(),
+        );
+        let mut elements = Vec::with_capacity(results.len());
+        for e in results.iter() {
             let retargeted_node = e.upcast::<EventTarget>().retarget(self.upcast());
             if let Some(element) = retargeted_node.downcast::<Element>().map(DomRoot::from_ref) {
                 elements.push(element);


### PR DESCRIPTION
⚡ Bolt: Optimize ElementsFromPoint allocation

💡 What: Replaced `.collect()` with `Vec::with_capacity` and an explicit `for` loop in `elements_from_point` in `documentorshadowroot.rs` and `ElementsFromPoint` in `shadowroot.rs`.
🎯 Why: Iterators containing `flat_map` and `filter_map` cannot provide exact size hints to `.collect()`, causing unexpected vector memory reallocations during element construction.
📊 Impact: Reduces allocation churn and intermediate closure usage. Pre-allocates arrays properly for the hit testing logic.
🔬 Measurement: Verified through manual logic tracing matching exact output parity and formatting via `rustfmt`.

---
*PR created automatically by Jules for task [7014383656738806337](https://jules.google.com/task/7014383656738806337) started by @RingCanary*