### PR TITLE
⚡ Bolt: Optimize HTMLCollection SupportedPropertyNames Deduplication

### DIFF
--- a/components/script/dom/html/htmlcollection.rs
+++ b/components/script/dom/html/htmlcollection.rs
@@ -4,6 +4,7 @@
 
 use std::cell::Cell;
 use std::cmp::Ordering;
+use std::collections::HashSet;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, QualName, local_name, namespace_url, ns};
@@ -220,9 +221,9 @@ impl HTMLCollection {
         match elem.prefix().as_ref() {
             None => elem.local_name() == qualified_name,
             Some(prefix) => {
-                qualified_name.starts_with(&**prefix) &&
-                    qualified_name.find(':') == Some(prefix.len()) &&
-                    qualified_name.ends_with(&**elem.local_name())
+                qualified_name.starts_with(&**prefix)
+                    && qualified_name.find(':') == Some(prefix.len())
+                    && qualified_name.ends_with(&**elem.local_name())
             },
         }
     }
@@ -253,9 +254,9 @@ impl HTMLCollection {
         }
         impl CollectionFilter for TagNameNSFilter {
             fn filter(&self, elem: &Element, _root: &Node) -> bool {
-                ((self.qname.ns == namespace_url!("*")) || (self.qname.ns == *elem.namespace())) &&
-                    ((self.qname.local == local_name!("*")) ||
-                        (self.qname.local == *elem.local_name()))
+                ((self.qname.ns == namespace_url!("*")) || (self.qname.ns == *elem.namespace()))
+                    && ((self.qname.local == local_name!("*"))
+                        || (self.qname.local == *elem.local_name()))
             }
         }
         let filter = TagNameNSFilter { qname };
@@ -415,8 +416,8 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
 
         // Step 2.
         self.elements_iter().find(|elem| {
-            elem.get_id().is_some_and(|id| id == key) ||
-                (elem.namespace() == &ns!(html) && elem.get_name().is_some_and(|id| id == key))
+            elem.get_id().is_some_and(|id| id == key)
+                || (elem.namespace() == &ns!(html) && elem.get_name().is_some_and(|id| id == key))
         })
     }
 
@@ -434,21 +435,25 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
     fn SupportedPropertyNames(&self) -> Vec<DOMString> {
         // Step 1
         let mut result = vec![];
+        // ⚡ Bolt Optimization: Use a HashSet to track seen elements instead of
+        // using `result.contains(...)`. This improves the time complexity of
+        // property name deduplication from O(N^2) to O(N).
+        let mut seen = HashSet::new();
 
         // Step 2
         for elem in self.elements_iter() {
             // Step 2.1
             if let Some(id_atom) = elem.get_id() {
-                let id_str = DOMString::from(&*id_atom);
-                if !result.contains(&id_str) {
+                if seen.insert(id_atom.clone()) {
+                    let id_str = DOMString::from(&*id_atom);
                     result.push(id_str);
                 }
             }
             // Step 2.2
             if *elem.namespace() == ns!(html) {
                 if let Some(name_atom) = elem.get_name() {
-                    let name_str = DOMString::from(&*name_atom);
-                    if !result.contains(&name_str) {
+                    if seen.insert(name_atom.clone()) {
+                        let name_str = DOMString::from(&*name_atom);
                         result.push(name_str)
                     }
                 }


### PR DESCRIPTION
⚡ Bolt Performance Boost: `HTMLCollection::SupportedPropertyNames`

This PR optimizes how property names are collected and deduplicated in `HTMLCollection`.

### 💡 What:
Replaced the O(N) `result.contains(...)` array search with an O(1) `HashSet::insert` check.
Crucially, it changes the order of operations to verify uniqueness via the `HashSet` *before* allocating `DOMString` wrappers.

### 🎯 Why:
The existing code allocated a `DOMString` for *every* element's `id` and `name` attribute in the collection, only to check if it was already in the `result` vector (O(N^2)). This caused heavy allocation churn and poor performance on larger DOM collections.

### 📊 Impact:
- **Algorithmic:** Time complexity drops from O(N^2) to O(N).
- **Memory:** Eliminates redundant string allocations for duplicate properties.

### 🔬 Measurement:
Standard WPT tests for HTMLCollection will ensure behavioral correctness (ordering is preserved). CPU profiling will show a reduction in string allocation overhead during iterations.

---
*PR created automatically by Jules for task [14356427006599598975](https://jules.google.com/task/14356427006599598975) started by @RingCanary*