### PR TITLE
⚡ Bolt: Optimize HTMLCollection::SupportedPropertyNames to O(N)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - HTMLCollection.SupportedPropertyNames O(N^2) optimization
+**Learning:** `HTMLCollection::SupportedPropertyNames` (in `components/script/dom/html/htmlcollection.rs`) iterates over HTML elements to extract unique ID and name properties. It used a loop checking uniqueness using `!result.contains(&id_str)` with O(N^2) complexity where elements are converted to `DOMString` and searched linearly.
+**Action:** Replaced linear searches with `HashSet::new()` to track uniqueness using the `Atom` types before they are converted to the allocated `DOMString`, reducing complexity to O(N) and drastically lowering allocation and parsing overhead in large collections.

--- a/components/script/dom/html/htmlcollection.rs
+++ b/components/script/dom/html/htmlcollection.rs
@@ -4,6 +4,7 @@
 
 use std::cell::Cell;
 use std::cmp::Ordering;
+use std::collections::HashSet;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, QualName, local_name, namespace_url, ns};
@@ -220,9 +221,9 @@ impl HTMLCollection {
         match elem.prefix().as_ref() {
             None => elem.local_name() == qualified_name,
             Some(prefix) => {
-                qualified_name.starts_with(&**prefix) &&
-                    qualified_name.find(':') == Some(prefix.len()) &&
-                    qualified_name.ends_with(&**elem.local_name())
+                qualified_name.starts_with(&**prefix)
+                    && qualified_name.find(':') == Some(prefix.len())
+                    && qualified_name.ends_with(&**elem.local_name())
             },
         }
     }
@@ -253,9 +254,9 @@ impl HTMLCollection {
         }
         impl CollectionFilter for TagNameNSFilter {
             fn filter(&self, elem: &Element, _root: &Node) -> bool {
-                ((self.qname.ns == namespace_url!("*")) || (self.qname.ns == *elem.namespace())) &&
-                    ((self.qname.local == local_name!("*")) ||
-                        (self.qname.local == *elem.local_name()))
+                ((self.qname.ns == namespace_url!("*")) || (self.qname.ns == *elem.namespace()))
+                    && ((self.qname.local == local_name!("*"))
+                        || (self.qname.local == *elem.local_name()))
             }
         }
         let filter = TagNameNSFilter { qname };
@@ -415,8 +416,8 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
 
         // Step 2.
         self.elements_iter().find(|elem| {
-            elem.get_id().is_some_and(|id| id == key) ||
-                (elem.namespace() == &ns!(html) && elem.get_name().is_some_and(|id| id == key))
+            elem.get_id().is_some_and(|id| id == key)
+                || (elem.namespace() == &ns!(html) && elem.get_name().is_some_and(|id| id == key))
         })
     }
 
@@ -434,22 +435,23 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
     fn SupportedPropertyNames(&self) -> Vec<DOMString> {
         // Step 1
         let mut result = vec![];
+        let mut seen = HashSet::new();
 
         // Step 2
         for elem in self.elements_iter() {
             // Step 2.1
             if let Some(id_atom) = elem.get_id() {
-                let id_str = DOMString::from(&*id_atom);
-                if !result.contains(&id_str) {
+                if seen.insert(id_atom.clone()) {
+                    let id_str = DOMString::from(&*id_atom);
                     result.push(id_str);
                 }
             }
             // Step 2.2
             if *elem.namespace() == ns!(html) {
                 if let Some(name_atom) = elem.get_name() {
-                    let name_str = DOMString::from(&*name_atom);
-                    if !result.contains(&name_str) {
-                        result.push(name_str)
+                    if seen.insert(name_atom.clone()) {
+                        let name_str = DOMString::from(&*name_atom);
+                        result.push(name_str);
                     }
                 }
             }


### PR DESCRIPTION
💡 **What:** Replaces O(N^2) linear searching with an O(N) `HashSet<Atom>` to track uniqueness of element IDs and names in `HTMLCollection::SupportedPropertyNames`.
🎯 **Why:** To improve performance by preventing string parsing overhead and linear iterations during HTMLCollection property checks.
📊 **Impact:** Reduces algorithmic complexity from $O(N^2)$ to $O(N)$ and decreases memory allocations for repeated properties.
🔬 **Measurement:** Verify by running `cargo test -p script htmlcollection`. Tests continue to pass, maintaining output guarantees and avoiding redundant iterations.

---
*PR created automatically by Jules for task [5965766473533047763](https://jules.google.com/task/5965766473533047763) started by @RingCanary*