### PR TITLE
⚡ Bolt: Optimize SupportedPropertyNames collections to O(N) time complexity using HashSet

### DIFF
--- a/components/script/dom/html/htmlcollection.rs
+++ b/components/script/dom/html/htmlcollection.rs
@@ -434,22 +434,21 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
     fn SupportedPropertyNames(&self) -> Vec<DOMString> {
         // Step 1
         let mut result = vec![];
+        let mut seen = std::collections::HashSet::new();
 
         // Step 2
         for elem in self.elements_iter() {
             // Step 2.1
             if let Some(id_atom) = elem.get_id() {
-                let id_str = DOMString::from(&*id_atom);
-                if !result.contains(&id_str) {
-                    result.push(id_str);
+                if seen.insert(id_atom.clone()) {
+                    result.push(DOMString::from(&*id_atom));
                 }
             }
             // Step 2.2
             if *elem.namespace() == ns!(html) {
                 if let Some(name_atom) = elem.get_name() {
-                    let name_str = DOMString::from(&*name_atom);
-                    if !result.contains(&name_str) {
-                        result.push(name_str)
+                    if seen.insert(name_atom.clone()) {
+                        result.push(DOMString::from(&*name_atom));
                     }
                 }
             }

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -639,8 +639,9 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
 
         // Step 7-8
         let mut names_vec: Vec<DOMString> = Vec::new();
+        let mut seen = std::collections::HashSet::new();
         for elem in sourced_names_vec.iter() {
-            if !names_vec.iter().any(|name| *name == *elem.name) {
+            if seen.insert(elem.name.clone()) {
                 names_vec.push(DOMString::from(&*elem.name));
             }
         }


### PR DESCRIPTION
💡 What: 
Replaced O(N^2) `.contains()` list deduplication loops inside `SupportedPropertyNames` with an O(1) `std::collections::HashSet` tracker in both `htmlcollection.rs` and `htmlformelement.rs`. Also optimized DOMString allocation by checking membership on the cheaper interned `Atom` clones before unconditionally allocating a `DOMString` wrapper for each seen element.

🎯 Why: 
The `SupportedPropertyNames` method builds up a collection of unique `id` and `name` attributes. The previous approach called `.contains()` on a `Vec<DOMString>` for every element to prevent duplicates. `Vec::contains` is a linear search O(N). Nested inside a for-loop, the overall algorithm was O(N^2). By maintaining a `HashSet` of seen `Atom`s, membership lookups become O(1), bringing the total execution time down to O(N).

📊 Impact: 
Time complexity reduced from O(N^2) to O(N) for `SupportedPropertyNames` collections. It prevents excessive string allocations since `DOMString::from` is now strictly called *after* a duplicate check rather than before.

🔬 Measurement: 
This algorithm changes only how uniqueness tracking is done. Testing verified that `seen.insert(...)` maintains original ordering since elements are only pushed into the result array when first encountered.

---
*PR created automatically by Jules for task [5407191420950258659](https://jules.google.com/task/5407191420950258659) started by @RingCanary*