### PR TITLE
⚡ Bolt: Optimize ElementsFromPoint layout queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Pre-allocating Vecs over `.flat_map().collect()`
+**Learning:** In Rust, `Vec::from_iter` (via `collect()`) fails to pre-allocate correctly when the iterator is a `FlatMap` or `FilterMap` due to vague size hints. This can cause unnecessary reallocations in hot paths like `elements_from_point` queries from the layout system.
+**Action:** Always prefer manually iterating with a pre-allocated `Vec::with_capacity(expected_len)` over `.flat_map(...).collect()` or `.filter_map(...).collect()` when the exact or upper bound length is known, especially in DOM API paths returning `Vec`.

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -207,16 +207,19 @@ impl DocumentOrShadowRoot {
         let nodes = self
             .window
             .elements_from_point_query(LayoutPoint::new(x, y), ElementsFromPointFlags::FindAll);
-        let mut elements: Vec<DomRoot<Element>> = nodes
-            .iter()
-            .flat_map(|result| {
-                // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
-                // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
-                let address = UntrustedNodeAddress(result.node.0 as *const c_void);
-                let node = unsafe { node::from_untrusted_node_address(address) };
-                DomRoot::downcast::<Element>(node)
-            })
-            .collect();
+
+        // Optimization: Pre-allocate capacity for results since flat_map obscures size hint.
+        // We allocate nodes.len() + 1 because the document_element might be appended in Step 4.
+        let mut elements = Vec::with_capacity(nodes.len() + 1);
+        for result in nodes {
+            // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
+            // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
+            let address = UntrustedNodeAddress(result.node.0 as *const c_void);
+            let node = unsafe { node::from_untrusted_node_address(address) };
+            if let Some(element) = DomRoot::downcast::<Element>(node) {
+                elements.push(element);
+            }
+        }
 
         // Step 4
         if let Some(root_element) = document_element {
@@ -336,8 +339,8 @@ impl DocumentOrShadowRoot {
     ) {
         debug!("Adding named element {:p}: {:p} id={}", self, element, id);
         assert!(
-            element.upcast::<Node>().is_in_a_document_tree() ||
-                element.upcast::<Node>().is_in_a_shadow_tree()
+            element.upcast::<Node>().is_in_a_document_tree()
+                || element.upcast::<Node>().is_in_a_shadow_tree()
         );
         assert!(!id.is_empty());
         let mut id_map = id_map.borrow_mut();

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -402,12 +402,16 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     fn ElementsFromPoint(&self, x: Finite<f64>, y: Finite<f64>) -> Vec<DomRoot<Element>> {
         // Return the result of running the retargeting algorithm with context object
         // and the original result as input
-        let mut elements = Vec::new();
-        for e in self
-            .document_or_shadow_root
-            .elements_from_point(x, y, None, self.document.has_browsing_context())
-            .iter()
-        {
+        let results = self.document_or_shadow_root.elements_from_point(
+            x,
+            y,
+            None,
+            self.document.has_browsing_context(),
+        );
+
+        // Optimization: Pre-allocate capacity for results
+        let mut elements = Vec::with_capacity(results.len());
+        for e in results {
             let retargeted_node = e.upcast::<EventTarget>().retarget(self.upcast());
             if let Some(element) = retargeted_node.downcast::<Element>().map(DomRoot::from_ref) {
                 elements.push(element);


### PR DESCRIPTION
💡 **What:** 
- Modified `elements_from_point` in `components/script/dom/documentorshadowroot.rs` to pre-allocate capacity instead of using `flat_map().collect()`. 
- Modified `ElementsFromPoint` in `components/script/dom/shadowroot.rs` to similarly pre-allocate capacity based on the length of returned elements from `document_or_shadow_root`.
- Documented learning to `.jules/bolt.md`.

🎯 **Why:** 
`.collect()` on iterator adapters like `flat_map` and `filter_map` fails to provide exact size hints. In hot layout query paths like hit testing, this triggers multiple vector re-allocations as results are filtered and appended. Pre-allocating fixes this O(N) memory churn.

📊 **Impact:** 
Reduces vector re-allocations to zero/one per query path, smoothing out CPU wait times for memory assignment during cursor movements or programmatic hit testing.

🔬 **Measurement:** 
Review `documentorshadowroot.rs` line ~215, observing how `with_capacity(nodes.len() + 1)` precisely matches the maximum elements to be appended via Step 4. Check `shadowroot.rs` where capacity is reserved via `results.len()`.

---
*PR created automatically by Jules for task [8973447076441057721](https://jules.google.com/task/8973447076441057721) started by @RingCanary*