### PR TITLE
⚡ Bolt: Optimize IFrame count using len() instead of iter().count()

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1615,7 +1615,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     /// <https://html.spec.whatwg.org/multipage/#accessing-other-browsing-contexts>
     fn Length(&self) -> u32 {
-        self.Document().iframes().iter().count() as u32
+        self.Document().iframes().len() as u32
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-parent>

--- a/components/script/iframe_collection.rs
+++ b/components/script/iframe_collection.rs
@@ -167,4 +167,12 @@ impl IFrameCollection {
     pub(crate) fn iter(&self) -> impl Iterator<Item = DomRoot<HTMLIFrameElement>> + use<'_> {
         self.iframes.iter().map(|iframe| iframe.element.as_rooted())
     }
+
+    pub(crate) fn len(&self) -> usize {
+        self.iframes.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.iframes.is_empty()
+    }
 }


### PR DESCRIPTION
💡 What: Added `len()` and `is_empty()` methods to `IFrameCollection` and updated `Window::Length` to use `.len()` instead of `.iter().count()`.

🎯 Why: The `IFrameCollection` is backed by a `Vec`. Counting elements via an iterator forces a linear O(N) scan. Accessing the underlying `Vec`'s length directly makes this an O(1) operation.

📊 Impact: Reduces time complexity of `Window::Length` (which maps to `window.length` in JavaScript) from O(N) to O(1), making it much faster when the document contains a large number of iframes.

🔬 Measurement: Verified the optimization by checking the internal structure of `IFrameCollection`. `window.length` access should be significantly faster in microbenchmarks parsing heavy ad-laden pages.

---
*PR created automatically by Jules for task [1467869772573302963](https://jules.google.com/task/1467869772573302963) started by @RingCanary*