### PR TITLE
⚡ Bolt: [performance improvement] O(1) property deduplication in HTMLCollection

### DIFF
--- a/components/script/dom/html/htmlcollection.rs
+++ b/components/script/dom/html/htmlcollection.rs
@@ -4,6 +4,7 @@
 
 use std::cell::Cell;
 use std::cmp::Ordering;
+use std::collections::HashSet;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, QualName, local_name, namespace_url, ns};
@@ -434,22 +435,21 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
     fn SupportedPropertyNames(&self) -> Vec<DOMString> {
         // Step 1
         let mut result = vec![];
+        let mut seen = HashSet::new();
 
         // Step 2
         for elem in self.elements_iter() {
             // Step 2.1
             if let Some(id_atom) = elem.get_id() {
-                let id_str = DOMString::from(&*id_atom);
-                if !result.contains(&id_str) {
-                    result.push(id_str);
+                if seen.insert(id_atom.clone()) {
+                    result.push(DOMString::from(&*id_atom));
                 }
             }
             // Step 2.2
             if *elem.namespace() == ns!(html) {
                 if let Some(name_atom) = elem.get_name() {
-                    let name_str = DOMString::from(&*name_atom);
-                    if !result.contains(&name_str) {
-                        result.push(name_str)
+                    if seen.insert(name_atom.clone()) {
+                        result.push(DOMString::from(&*name_atom));
                     }
                 }
             }


### PR DESCRIPTION
💡 What: The `SupportedPropertyNames` method in `HTMLCollection` now uses a `HashSet<Atom>` to track seen IDs and names instead of calling `Vec::contains()` on the result array for every item. It also defers the conversion from `Atom` to `DOMString` until after verifying the `Atom` is unique.

🎯 Why: The previous implementation resulted in an O(N^2) operation because `!result.contains(&id_str)` did an O(N) scan per element over the growing `Vec`. It also unnecessarily allocated a `DOMString` (`DOMString::from(&*id_atom)`) for every ID and name, even if they were duplicates.

📊 Impact: 
1. Lookup complexity drops from O(N^2) to O(N).
2. Avoids unnecessary heap allocation (`DOMString`) for duplicate `id` and `name` attributes. Cloning an `Atom` just increments an internal reference count, whereas `DOMString::from` allocates memory.

🔬 Measurement: Run JavaScript loops that invoke `.namedItem()` or check property keys on a large `HTMLCollection` with numerous nested or duplicated IDs/names. It will demonstrate a tangible reduction in execution time and memory allocations.

---
*PR created automatically by Jules for task [11568783570766685943](https://jules.google.com/task/11568783570766685943) started by @RingCanary*