### PR TITLE
⚡ Bolt: [performance improvement] O(N^2) to O(N) in HTMLCollection SupportedPropertyNames

### DIFF
--- a/components/script/dom/html/htmlcollection.rs
+++ b/components/script/dom/html/htmlcollection.rs
@@ -220,9 +220,9 @@ impl HTMLCollection {
         match elem.prefix().as_ref() {
             None => elem.local_name() == qualified_name,
             Some(prefix) => {
-                qualified_name.starts_with(&**prefix) &&
-                    qualified_name.find(':') == Some(prefix.len()) &&
-                    qualified_name.ends_with(&**elem.local_name())
+                qualified_name.starts_with(&**prefix)
+                    && qualified_name.find(':') == Some(prefix.len())
+                    && qualified_name.ends_with(&**elem.local_name())
             },
         }
     }
@@ -253,9 +253,9 @@ impl HTMLCollection {
         }
         impl CollectionFilter for TagNameNSFilter {
             fn filter(&self, elem: &Element, _root: &Node) -> bool {
-                ((self.qname.ns == namespace_url!("*")) || (self.qname.ns == *elem.namespace())) &&
-                    ((self.qname.local == local_name!("*")) ||
-                        (self.qname.local == *elem.local_name()))
+                ((self.qname.ns == namespace_url!("*")) || (self.qname.ns == *elem.namespace()))
+                    && ((self.qname.local == local_name!("*"))
+                        || (self.qname.local == *elem.local_name()))
             }
         }
         let filter = TagNameNSFilter { qname };
@@ -415,8 +415,8 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
 
         // Step 2.
         self.elements_iter().find(|elem| {
-            elem.get_id().is_some_and(|id| id == key) ||
-                (elem.namespace() == &ns!(html) && elem.get_name().is_some_and(|id| id == key))
+            elem.get_id().is_some_and(|id| id == key)
+                || (elem.namespace() == &ns!(html) && elem.get_name().is_some_and(|id| id == key))
         })
     }
 
@@ -434,22 +434,21 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
     fn SupportedPropertyNames(&self) -> Vec<DOMString> {
         // Step 1
         let mut result = vec![];
+        let mut seen = std::collections::HashSet::new();
 
         // Step 2
         for elem in self.elements_iter() {
             // Step 2.1
             if let Some(id_atom) = elem.get_id() {
-                let id_str = DOMString::from(&*id_atom);
-                if !result.contains(&id_str) {
-                    result.push(id_str);
+                if seen.insert(id_atom.clone()) {
+                    result.push(DOMString::from(&*id_atom));
                 }
             }
             // Step 2.2
             if *elem.namespace() == ns!(html) {
                 if let Some(name_atom) = elem.get_name() {
-                    let name_str = DOMString::from(&*name_atom);
-                    if !result.contains(&name_str) {
-                        result.push(name_str)
+                    if seen.insert(name_atom.clone()) {
+                        result.push(DOMString::from(&*name_atom));
                     }
                 }
             }


### PR DESCRIPTION
💡 What: Replaced the O(N^2) `Vec::contains` check with a `std::collections::HashSet` that checks unique IDs and names using the underlying `Atom`s in `HTMLCollection::SupportedPropertyNames`.

🎯 Why: In the previous implementation, every element in the HTMLCollection required creating a `DOMString` from its `id`/`name` atom, and then traversing the `result` vector (which grows up to size N) to check for uniqueness. This is an O(N^2) time complexity operation with unnecessary string allocations for duplicate values. `Atom` from `stylo_atoms` is an interned string, meaning cloning and hashing it is extremely cheap.

📊 Impact: Reduces time complexity from O(N^2) to amortized O(N) when generating the list of supported property names on an HTMLCollection. Also drastically reduces heap allocation by deferring the `DOMString` creation until the atom is confirmed unique.

🔬 Measurement: Run a JS script that accesses the property names of a large `HTMLCollection` (e.g. `document.forms` or `document.getElementsByTagName("*")` containing thousands of elements with overlapping names/IDs). Performance impact can be seen in layout/JS profiles, especially when traversing complex DOM trees. Verified through manual review and successful compilation/formatting.

---
*PR created automatically by Jules for task [7271023227351154507](https://jules.google.com/task/7271023227351154507) started by @RingCanary*