### PR TITLE
⚡ Bolt: [performance improvement] Optimize `Window::Length` to O(1)

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1615,7 +1615,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     /// <https://html.spec.whatwg.org/multipage/#accessing-other-browsing-contexts>
     fn Length(&self) -> u32 {
-        self.Document().iframes().iter().count() as u32
+        self.Document().iframes().len() as u32
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-parent>


### PR DESCRIPTION
💡 What: Replaced `.iter().count()` with `.len()` in `Window::Length`.
🎯 Why: `.iter().count()` traverses the whole iterator which is potentially O(N), whereas `.len()` directly queries the length of the underlying iframe collection in O(1) time. 
📊 Impact: Speeds up querying `window.length` from O(N) to O(1) by removing unnecessary iterator allocation and traversal.
🔬 Measurement: Code analysis confirms `iframes` exposes a `.len()` method that returns the pre-computed collection size. Tested to confirm the method builds correctly.

---
*PR created automatically by Jules for task [8270380637795669408](https://jules.google.com/task/8270380637795669408) started by @RingCanary*