### PR TITLE
⚡ Bolt: [performance improvement] Use O(1) len() instead of O(N) iter().count() for IFrameCollection

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1615,7 +1615,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     /// <https://html.spec.whatwg.org/multipage/#accessing-other-browsing-contexts>
     fn Length(&self) -> u32 {
-        self.Document().iframes().iter().count() as u32
+        self.Document().iframes().len() as u32
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-parent>

--- a/components/script/iframe_collection.rs
+++ b/components/script/iframe_collection.rs
@@ -167,4 +167,12 @@ impl IFrameCollection {
     pub(crate) fn iter(&self) -> impl Iterator<Item = DomRoot<HTMLIFrameElement>> + use<'_> {
         self.iframes.iter().map(|iframe| iframe.element.as_rooted())
     }
+
+    pub(crate) fn len(&self) -> usize {
+        self.iframes.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.iframes.is_empty()
+    }
 }


### PR DESCRIPTION
💡 **What**: Added `len()` and `is_empty()` methods to `IFrameCollection` and updated `Window::Length` to use `.len()` instead of `.iter().count()`.

🎯 **Why**: The previous implementation in `Window::Length` used `self.Document().iframes().iter().count()`. The `.iter()` method maps over the internal vector of `IFrame` structs and calls `iframe.element.as_rooted()`, which incurs atomic reference-counting overhead for every iframe in the document, resulting in an O(N) operation just to get the length. Since `IFrameCollection` stores the elements in a `Vec`, returning its length is a trivial O(1) operation.

📊 **Impact**: Reduces `Window.length` lookup from O(N) (with N ref-count increments/decrements) to O(1) direct vector length lookup. Speedup scales linearly with the number of iframes in the document.

🔬 **Measurement**: Manual logic verification. Performance improves for pages that query `window.length` repeatedly.

---
*PR created automatically by Jules for task [7299897465452565988](https://jules.google.com/task/7299897465452565988) started by @RingCanary*