### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+## 2024-03-26 - [IFrameCollection Length Optimization]
+**Learning:** Found an `O(N)` performance bottleneck where `.iter().count()` was used to count items in `IFrameCollection`, when `IFrameCollection` wraps a `Vec` and could easily expose a `len()` method for `O(1)` counting.
+**Action:** Always check if a collection wrapping a basic type like `Vec` can expose `len()` instead of relying on iterators.
+
+## 2024-03-26 - [DOMString::from(&*atom) allocation and uniqueness check optimization]
+**Learning:** Found an O(N^2) complexity issue combined with unnecessary allocations in `HTMLCollection::SupportedPropertyNames`. The function iterates over elements, converts `Atom` IDs/names to `DOMString` (which allocates), and then uses `Vec::contains` (O(N) check) to ensure uniqueness before pushing.
+**Action:** When filtering unique items represented as `Atom`s, use a `HashSet<Atom>` for O(1) uniqueness checks. `Atom` cloning is cheap. Defer the expensive conversion to `DOMString` until after the uniqueness check confirms it's a new item.

--- a/components/script/dom/html/htmlcollection.rs
+++ b/components/script/dom/html/htmlcollection.rs
@@ -220,9 +220,9 @@ impl HTMLCollection {
         match elem.prefix().as_ref() {
             None => elem.local_name() == qualified_name,
             Some(prefix) => {
-                qualified_name.starts_with(&**prefix) &&
-                    qualified_name.find(':') == Some(prefix.len()) &&
-                    qualified_name.ends_with(&**elem.local_name())
+                qualified_name.starts_with(&**prefix)
+                    && qualified_name.find(':') == Some(prefix.len())
+                    && qualified_name.ends_with(&**elem.local_name())
             },
         }
     }
@@ -253,9 +253,9 @@ impl HTMLCollection {
         }
         impl CollectionFilter for TagNameNSFilter {
             fn filter(&self, elem: &Element, _root: &Node) -> bool {
-                ((self.qname.ns == namespace_url!("*")) || (self.qname.ns == *elem.namespace())) &&
-                    ((self.qname.local == local_name!("*")) ||
-                        (self.qname.local == *elem.local_name()))
+                ((self.qname.ns == namespace_url!("*")) || (self.qname.ns == *elem.namespace()))
+                    && ((self.qname.local == local_name!("*"))
+                        || (self.qname.local == *elem.local_name()))
             }
         }
         let filter = TagNameNSFilter { qname };
@@ -415,8 +415,8 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
 
         // Step 2.
         self.elements_iter().find(|elem| {
-            elem.get_id().is_some_and(|id| id == key) ||
-                (elem.namespace() == &ns!(html) && elem.get_name().is_some_and(|id| id == key))
+            elem.get_id().is_some_and(|id| id == key)
+                || (elem.namespace() == &ns!(html) && elem.get_name().is_some_and(|id| id == key))
         })
     }
 
@@ -434,22 +434,23 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
     fn SupportedPropertyNames(&self) -> Vec<DOMString> {
         // Step 1
         let mut result = vec![];
+        // Optimization: Use HashSet for O(1) deduplication instead of Vec::contains which is O(N)
+        let mut seen = std::collections::HashSet::new();
 
         // Step 2
         for elem in self.elements_iter() {
             // Step 2.1
             if let Some(id_atom) = elem.get_id() {
-                let id_str = DOMString::from(&*id_atom);
-                if !result.contains(&id_str) {
-                    result.push(id_str);
+                if seen.insert(id_atom.clone()) {
+                    // Optimization: Defer expensive DOMString allocation until after uniqueness check
+                    result.push(DOMString::from(&*id_atom));
                 }
             }
             // Step 2.2
             if *elem.namespace() == ns!(html) {
                 if let Some(name_atom) = elem.get_name() {
-                    let name_str = DOMString::from(&*name_atom);
-                    if !result.contains(&name_str) {
-                        result.push(name_str)
+                    if seen.insert(name_atom.clone()) {
+                        result.push(DOMString::from(&*name_atom));
                     }
                 }
             }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1365,9 +1365,9 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             let is_auxiliary = window_proxy.is_auxiliary();
 
             // https://html.spec.whatwg.org/multipage/#script-closable
-            let is_script_closable = (self.is_top_level() && history_length == 1) ||
-                is_auxiliary ||
-                pref!(dom_allow_scripts_to_close_windows);
+            let is_script_closable = (self.is_top_level() && history_length == 1)
+                || is_auxiliary
+                || pref!(dom_allow_scripts_to_close_windows);
 
             // TODO: rest of Step 3:
             // Is the incumbent settings object's responsible browsing context familiar with current?
@@ -1615,7 +1615,8 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     /// <https://html.spec.whatwg.org/multipage/#accessing-other-browsing-contexts>
     fn Length(&self) -> u32 {
-        self.Document().iframes().iter().count() as u32
+        // Optimization: Use O(1) len() instead of O(N) iter().count()
+        self.Document().iframes().len() as u32
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-parent>
@@ -1814,8 +1815,8 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
                 iframe
                     .browsing_context_id()
                     .as_ref()
-                    .map(BrowsingContextId::to_string) ==
-                    Some(browsing_context_id.to_string())
+                    .map(BrowsingContextId::to_string)
+                    == Some(browsing_context_id.to_string())
             })
             .and_then(|iframe| iframe.GetContentWindow())
     }
@@ -2247,10 +2248,10 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
                     return true;
                 }
                 match type_ {
-                    HTMLElementTypeId::HTMLEmbedElement |
-                    HTMLElementTypeId::HTMLFormElement |
-                    HTMLElementTypeId::HTMLImageElement |
-                    HTMLElementTypeId::HTMLObjectElement => {
+                    HTMLElementTypeId::HTMLEmbedElement
+                    | HTMLElementTypeId::HTMLFormElement
+                    | HTMLElementTypeId::HTMLImageElement
+                    | HTMLElementTypeId::HTMLObjectElement => {
                         elem.get_name().as_ref() == Some(&self.name)
                     },
                     _ => false,
@@ -2568,8 +2569,8 @@ impl Window {
         // layouts (for queries and scrolling) are not blocked, as they do not display
         // anything and script expects the layout to be up-to-date after they run.
         let pipeline_id = self.pipeline_id();
-        if reflow_goal == ReflowGoal::UpdateTheRendering &&
-            self.layout_blocker.get().layout_blocked()
+        if reflow_goal == ReflowGoal::UpdateTheRendering
+            && self.layout_blocker.get().layout_blocked()
         {
             debug!("Suppressing pre-load-event reflow pipeline {pipeline_id}");
             return ReflowPhasesRun::empty();
@@ -2677,8 +2678,8 @@ impl Window {
         // See http://testthewebforward.org/docs/reftests.html
         // and https://web-platform-tests.org/writing-tests/crashtest.html
         if document.GetDocumentElement().is_some_and(|elem| {
-            elem.has_class(&atom!("reftest-wait"), CaseSensitivity::CaseSensitive) ||
-                elem.has_class(&Atom::from("test-wait"), CaseSensitivity::CaseSensitive)
+            elem.has_class(&atom!("reftest-wait"), CaseSensitivity::CaseSensitive)
+                || elem.has_class(&Atom::from("test-wait"), CaseSensitivity::CaseSensitive)
         }) {
             return;
         }
@@ -2691,8 +2692,8 @@ impl Window {
             return;
         }
 
-        if !self.pending_layout_images.borrow().is_empty() ||
-            !self.pending_images_for_rasterization.borrow().is_empty()
+        if !self.pending_layout_images.borrow().is_empty()
+            || !self.pending_images_for_rasterization.borrow().is_empty()
         {
             return;
         }
@@ -3784,10 +3785,10 @@ fn should_move_clip_rect(clip_rect: UntypedRect<Au>, new_viewport: UntypedRect<f
     static VIEWPORT_SCROLL_MARGIN_SIZE: f32 = 0.5;
     let viewport_scroll_margin = new_viewport.size * VIEWPORT_SCROLL_MARGIN_SIZE;
 
-    (clip_rect.origin.x - new_viewport.origin.x).abs() <= viewport_scroll_margin.width ||
-        (clip_rect.max_x() - new_viewport.max_x()).abs() <= viewport_scroll_margin.width ||
-        (clip_rect.origin.y - new_viewport.origin.y).abs() <= viewport_scroll_margin.height ||
-        (clip_rect.max_y() - new_viewport.max_y()).abs() <= viewport_scroll_margin.height
+    (clip_rect.origin.x - new_viewport.origin.x).abs() <= viewport_scroll_margin.width
+        || (clip_rect.max_x() - new_viewport.max_x()).abs() <= viewport_scroll_margin.width
+        || (clip_rect.origin.y - new_viewport.origin.y).abs() <= viewport_scroll_margin.height
+        || (clip_rect.max_y() - new_viewport.max_y()).abs() <= viewport_scroll_margin.height
 }
 
 impl Window {
@@ -3888,10 +3889,10 @@ fn is_named_element_with_name_attribute(elem: &Element) -> bool {
     };
     matches!(
         type_,
-        HTMLElementTypeId::HTMLEmbedElement |
-            HTMLElementTypeId::HTMLFormElement |
-            HTMLElementTypeId::HTMLImageElement |
-            HTMLElementTypeId::HTMLObjectElement
+        HTMLElementTypeId::HTMLEmbedElement
+            | HTMLElementTypeId::HTMLFormElement
+            | HTMLElementTypeId::HTMLImageElement
+            | HTMLElementTypeId::HTMLObjectElement
     )
 }
 

--- a/components/script/iframe_collection.rs
+++ b/components/script/iframe_collection.rs
@@ -164,6 +164,14 @@ impl IFrameCollection {
         }
     }
 
+    pub(crate) fn len(&self) -> usize {
+        self.iframes.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.iframes.is_empty()
+    }
+
     pub(crate) fn iter(&self) -> impl Iterator<Item = DomRoot<HTMLIFrameElement>> + use<'_> {
         self.iframes.iter().map(|iframe| iframe.element.as_rooted())
     }


### PR DESCRIPTION
💡 **What:**
1. Replaced `O(N)` `.iter().count()` with `O(1)` `.len()` in `IFrameCollection::len()` and used it in `Window::Length`.
2. Optimized uniqueness checks in `HTMLCollection::SupportedPropertyNames` by switching from `Vec::contains` `O(N)` on allocated `DOMString`s to `std::collections::HashSet` `O(1)` on `Atom`s, significantly reducing allocations. Added inline comments to document the optimizations.

🎯 **Why:**
1. Repeated iteration over `IFrameCollection` for a simple count was creating unnecessary `O(N)` overhead in `Window::Length()`. The length of the underlying `Vec` is readily available.
2. In `HTMLCollection::SupportedPropertyNames`, checking string presence with `.contains()` in a vector makes the entire operation `O(N^2)`. Furthermore, converting `Atom` to `DOMString` during every iteration step (even for duplicates) caused needless string allocations.

📊 **Impact:**
1. Counting iframes goes from `O(N)` to `O(1)`, reducing CPU overhead.
2. Collecting unique supported property names from an `HTMLCollection` goes from `O(N^2)` with frequent allocations to `O(N)` with minimal allocations (since `Atom` cloning is a cheap pointer clone and `DOMString` allocation only happens for unique names).

🔬 **Measurement:**
Run microbenchmarks containing loops of unique operations, verify via code review that iteration overheads map correctly to `O(1)` abstractions where appropriate.

---
*PR created automatically by Jules for task [18142178808172358818](https://jules.google.com/task/18142178808172358818) started by @RingCanary*