### PR TITLE
⚡ Bolt: Optimize SupportedPropertyNames to O(N) deduplication using HashSet

### DIFF
--- a/components/script/dom/html/htmlcollection.rs
+++ b/components/script/dom/html/htmlcollection.rs
@@ -220,9 +220,9 @@ impl HTMLCollection {
         match elem.prefix().as_ref() {
             None => elem.local_name() == qualified_name,
             Some(prefix) => {
-                qualified_name.starts_with(&**prefix) &&
-                    qualified_name.find(':') == Some(prefix.len()) &&
-                    qualified_name.ends_with(&**elem.local_name())
+                qualified_name.starts_with(&**prefix)
+                    && qualified_name.find(':') == Some(prefix.len())
+                    && qualified_name.ends_with(&**elem.local_name())
             },
         }
     }
@@ -253,9 +253,9 @@ impl HTMLCollection {
         }
         impl CollectionFilter for TagNameNSFilter {
             fn filter(&self, elem: &Element, _root: &Node) -> bool {
-                ((self.qname.ns == namespace_url!("*")) || (self.qname.ns == *elem.namespace())) &&
-                    ((self.qname.local == local_name!("*")) ||
-                        (self.qname.local == *elem.local_name()))
+                ((self.qname.ns == namespace_url!("*")) || (self.qname.ns == *elem.namespace()))
+                    && ((self.qname.local == local_name!("*"))
+                        || (self.qname.local == *elem.local_name()))
             }
         }
         let filter = TagNameNSFilter { qname };
@@ -415,8 +415,8 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
 
         // Step 2.
         self.elements_iter().find(|elem| {
-            elem.get_id().is_some_and(|id| id == key) ||
-                (elem.namespace() == &ns!(html) && elem.get_name().is_some_and(|id| id == key))
+            elem.get_id().is_some_and(|id| id == key)
+                || (elem.namespace() == &ns!(html) && elem.get_name().is_some_and(|id| id == key))
         })
     }
 
@@ -434,22 +434,23 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
     fn SupportedPropertyNames(&self) -> Vec<DOMString> {
         // Step 1
         let mut result = vec![];
+        let mut seen = std::collections::HashSet::new();
 
         // Step 2
         for elem in self.elements_iter() {
             // Step 2.1
             if let Some(id_atom) = elem.get_id() {
-                let id_str = DOMString::from(&*id_atom);
-                if !result.contains(&id_str) {
-                    result.push(id_str);
+                // Optimization: Use HashSet<Atom> for O(1) deduplication instead of Vec::contains (O(N)),
+                // and avoid allocating DOMString until uniqueness is confirmed.
+                if seen.insert(id_atom.clone()) {
+                    result.push(DOMString::from(&*id_atom));
                 }
             }
             // Step 2.2
             if *elem.namespace() == ns!(html) {
                 if let Some(name_atom) = elem.get_name() {
-                    let name_str = DOMString::from(&*name_atom);
-                    if !result.contains(&name_str) {
-                        result.push(name_str)
+                    if seen.insert(name_atom.clone()) {
+                        result.push(DOMString::from(&*name_atom));
                     }
                 }
             }


### PR DESCRIPTION
**💡 What:** 
Modified the `SupportedPropertyNames` method in `components/script/dom/html/htmlcollection.rs` to use `std::collections::HashSet<Atom>` instead of relying on `Vec::contains()` to track seen IDs and Names. It also defers the creation of `DOMString` from the `Atom` until we are strictly sure it hasn't been seen before.

**🎯 Why:** 
The previous implementation iterated through all elements (N) and for each element checked if the accumulated result vector already contained the `DOMString` using `contains()`, which scales as $O(M)$ where M is the number of accumulated properties. This resulted in an overall $O(N^2)$ algorithmic time complexity. Furthermore, it eagerly allocated a `DOMString` for every single element, even if it turned out to be a duplicate.

**📊 Impact:** 
- Time complexity reduced from $O(N^2)$ to $O(N)$ amortized.
- Memory allocation significantly reduced by deferring `DOMString` heap allocation until uniqueness is confirmed. `Atom` cloning is virtually zero-cost.

**🔬 Measurement:** 
Run `mach test-tidy` and check logic. Any page utilizing `document.getElementsByTagName(...)[prop]` or similar generic `SupportedPropertyNames` indexing will execute this code path.

---
*PR created automatically by Jules for task [4151209960395569441](https://jules.google.com/task/4151209960395569441) started by @RingCanary*