### PR TITLE
⚡ Bolt: Optimize ElementsFromPoint allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,6 @@
+## 2026-04-03 - Optimize ElementsFromPoint allocations
+**Learning:** In Rust,  (via `collect()`) fails to pre-allocate correctly when the iterator is a `FlatMap` or `FilterMap` due to vague size hints, forcing repeated reallocations on the heap as elements are yielded.
+**Action:** When the upper bounds are known (like downcasting nodes fetched from a query), prefer  and an explicit  loop to build the collection without reallocations.
+## 2024-05-24 - Optimize ElementsFromPoint allocations
+**Learning:** In Rust, `Vec::from_iter` (via `collect()`) fails to pre-allocate correctly when the iterator is a `FlatMap` or `FilterMap` due to vague size hints, forcing repeated reallocations on the heap as elements are yielded.
+**Action:** When the upper bounds are known (like downcasting nodes fetched from a query), prefer `Vec::with_capacity` and an explicit `for` loop to build the collection without reallocations.

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -207,16 +207,17 @@ impl DocumentOrShadowRoot {
         let nodes = self
             .window
             .elements_from_point_query(LayoutPoint::new(x, y), ElementsFromPointFlags::FindAll);
-        let mut elements: Vec<DomRoot<Element>> = nodes
-            .iter()
-            .flat_map(|result| {
-                // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
-                // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
-                let address = UntrustedNodeAddress(result.node.0 as *const c_void);
-                let node = unsafe { node::from_untrusted_node_address(address) };
-                DomRoot::downcast::<Element>(node)
-            })
-            .collect();
+
+        let mut elements = Vec::with_capacity(nodes.len() + 1);
+        for result in nodes.iter() {
+            // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
+            // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
+            let address = UntrustedNodeAddress(result.node.0 as *const c_void);
+            let node = unsafe { node::from_untrusted_node_address(address) };
+            if let Some(element) = DomRoot::downcast::<Element>(node) {
+                elements.push(element);
+            }
+        }
 
         // Step 4
         if let Some(root_element) = document_element {
@@ -336,8 +337,8 @@ impl DocumentOrShadowRoot {
     ) {
         debug!("Adding named element {:p}: {:p} id={}", self, element, id);
         assert!(
-            element.upcast::<Node>().is_in_a_document_tree() ||
-                element.upcast::<Node>().is_in_a_shadow_tree()
+            element.upcast::<Node>().is_in_a_document_tree()
+                || element.upcast::<Node>().is_in_a_shadow_tree()
         );
         assert!(!id.is_empty());
         let mut id_map = id_map.borrow_mut();

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -402,12 +402,15 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     fn ElementsFromPoint(&self, x: Finite<f64>, y: Finite<f64>) -> Vec<DomRoot<Element>> {
         // Return the result of running the retargeting algorithm with context object
         // and the original result as input
-        let mut elements = Vec::new();
-        for e in self
-            .document_or_shadow_root
-            .elements_from_point(x, y, None, self.document.has_browsing_context())
-            .iter()
-        {
+        let source_elements = self.document_or_shadow_root.elements_from_point(
+            x,
+            y,
+            None,
+            self.document.has_browsing_context(),
+        );
+
+        let mut elements = Vec::with_capacity(source_elements.len());
+        for e in source_elements.iter() {
             let retargeted_node = e.upcast::<EventTarget>().retarget(self.upcast());
             if let Some(element) = retargeted_node.downcast::<Element>().map(DomRoot::from_ref) {
                 elements.push(element);


### PR DESCRIPTION
💡 **What**: Replaced `nodes.iter().flat_map(...).collect()` in `elements_from_point` and `ElementsFromPoint` with explicitly pre-allocated `Vec::with_capacity` and `for` loops.

🎯 **Why**: When an iterator pipeline ends with `flat_map()` or `filter_map()`, standard `collect()` receives an imprecise `size_hint()`. This means `Vec::from_iter` cannot pre-allocate enough memory, resulting in multiple expensive heap reallocations as the vector grows.

📊 **Impact**: Hit-testing is a highly active codepath (mouse events). This change prevents 100% of the dynamic vector reallocation overhead during these calls by pre-allocating the vector exact bounds, yielding an O(1) allocation cost instead of amortized O(N).

🔬 **Measurement**: Verify by using hit-testing heavily in devtools or mouseovers. Memory profile (or `valgrind`) will show fewer `realloc()` calls during standard mouse movement events that trigger `ElementsFromPoint` lookups.

---
*PR created automatically by Jules for task [11189452110867415214](https://jules.google.com/task/11189452110867415214) started by @RingCanary*