### PR TITLE
⚡ Bolt: [performance improvement] Optimize uniqueness checks with HashSet in DOM collections

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-28 - [HashSet Tracking for Uniqueness to Avoid O(N^2) Overheads]
+**Learning:** During iteration over DOM properties like SupportedPropertyNames, using `Vec::contains` or `iter().any` adds up to an O(N^2) complexity cost in Rust due to scanning. Additionally, deferring allocations (like `DOMString::from` mapping to JS strings) significantly boosts performance.
+**Action:** When mapping over iterators for distinct property collections, always favor checking uniqueness with `HashSet` (using `Atom`s or `&str` references directly where feasible). Only perform string conversions via allocations on items definitively marked as unique.

--- a/components/script/dom/html/htmlcollection.rs
+++ b/components/script/dom/html/htmlcollection.rs
@@ -434,22 +434,21 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
     fn SupportedPropertyNames(&self) -> Vec<DOMString> {
         // Step 1
         let mut result = vec![];
+        let mut seen = std::collections::HashSet::new();
 
         // Step 2
         for elem in self.elements_iter() {
             // Step 2.1
             if let Some(id_atom) = elem.get_id() {
-                let id_str = DOMString::from(&*id_atom);
-                if !result.contains(&id_str) {
-                    result.push(id_str);
+                if seen.insert(id_atom.clone()) {
+                    result.push(DOMString::from(&*id_atom));
                 }
             }
             // Step 2.2
             if *elem.namespace() == ns!(html) {
                 if let Some(name_atom) = elem.get_name() {
-                    let name_str = DOMString::from(&*name_atom);
-                    if !result.contains(&name_str) {
-                        result.push(name_str)
+                    if seen.insert(name_atom.clone()) {
+                        result.push(DOMString::from(&*name_atom));
                     }
                 }
             }

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -639,8 +639,9 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
 
         // Step 7-8
         let mut names_vec: Vec<DOMString> = Vec::new();
+        let mut seen = std::collections::HashSet::new();
         for elem in sourced_names_vec.iter() {
-            if !names_vec.iter().any(|name| *name == *elem.name) {
+            if seen.insert(elem.name.clone()) {
                 names_vec.push(DOMString::from(&*elem.name));
             }
         }

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -108,6 +108,7 @@ impl NamedNodeMapMethods<crate::DomTypeHolder> for NamedNodeMap {
     /// <https://heycam.github.io/webidl/#dfn-supported-property-names>
     fn SupportedPropertyNames(&self) -> Vec<DOMString> {
         let mut names = vec![];
+        let mut seen = std::collections::HashSet::new();
         let html_element_in_html_document = self.owner.html_element_in_html_document();
         for attr in self.owner.attrs().iter() {
             let s = &**attr.name();
@@ -115,7 +116,7 @@ impl NamedNodeMapMethods<crate::DomTypeHolder> for NamedNodeMap {
                 continue;
             }
 
-            if !names.iter().any(|name| name == s) {
+            if seen.insert(s) {
                 names.push(DOMString::from(s));
             }
         }


### PR DESCRIPTION
What: 
Replaced O(N) array scanning for deduplication with an O(1) `HashSet` in three DOM collection files (`htmlcollection.rs`, `htmlformelement.rs`, `namednodemap.rs`), and deferred the allocation of `DOMString::from` mapping to JS strings.

Why: 
To eliminate O(N^2) time complexity during properties iteration which is a common anti-pattern that slows down property access iteration. Also prevents eager String wrapper allocations.

Impact: 
Reduces the uniqueness lookup time complexity from O(N^2) to O(N). Avoids unnecessary memory allocations for non-unique string identifiers.

Measurement: 
Verification was done manually due to test runner limitations; code structure is clearly O(N). Standard checks passed.

---
*PR created automatically by Jules for task [12858755022674124878](https://jules.google.com/task/12858755022674124878) started by @RingCanary*