### PR TITLE
⚡ Bolt: [performance improvement] Pre-allocate vectors in elements_from_point

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-19 - Pre-allocating Vec in chained iterators
+**Learning:** In Rust, chained iterators like `flat_map().collect()` or `filter_map().collect()` often obscure the exact size hint of the resulting collection. This causes `Vec::from_iter` (called by `collect`) to allocate conservatively or reallocate repeatedly, leading to allocation churn in hot paths like layout querying (`elements_from_point`).
+**Action:** When the maximum bounds of an iterator are known (e.g., from an initial `nodes.len()`), replace `collect()` with explicit `Vec::with_capacity(max_size)` followed by `.extend()` or a `for` loop to guarantee a single memory allocation.

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -207,16 +207,15 @@ impl DocumentOrShadowRoot {
         let nodes = self
             .window
             .elements_from_point_query(LayoutPoint::new(x, y), ElementsFromPointFlags::FindAll);
-        let mut elements: Vec<DomRoot<Element>> = nodes
-            .iter()
-            .flat_map(|result| {
-                // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
-                // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
-                let address = UntrustedNodeAddress(result.node.0 as *const c_void);
-                let node = unsafe { node::from_untrusted_node_address(address) };
-                DomRoot::downcast::<Element>(node)
-            })
-            .collect();
+
+        let mut elements: Vec<DomRoot<Element>> = Vec::with_capacity(nodes.len() + 1);
+        elements.extend(nodes.iter().filter_map(|result| {
+            // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
+            // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
+            let address = UntrustedNodeAddress(result.node.0 as *const c_void);
+            let node = unsafe { node::from_untrusted_node_address(address) };
+            DomRoot::downcast::<Element>(node)
+        }));
 
         // Step 4
         if let Some(root_element) = document_element {
@@ -336,8 +335,8 @@ impl DocumentOrShadowRoot {
     ) {
         debug!("Adding named element {:p}: {:p} id={}", self, element, id);
         assert!(
-            element.upcast::<Node>().is_in_a_document_tree() ||
-                element.upcast::<Node>().is_in_a_shadow_tree()
+            element.upcast::<Node>().is_in_a_document_tree()
+                || element.upcast::<Node>().is_in_a_shadow_tree()
         );
         assert!(!id.is_empty());
         let mut id_map = id_map.borrow_mut();

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -402,12 +402,15 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     fn ElementsFromPoint(&self, x: Finite<f64>, y: Finite<f64>) -> Vec<DomRoot<Element>> {
         // Return the result of running the retargeting algorithm with context object
         // and the original result as input
-        let mut elements = Vec::new();
-        for e in self
-            .document_or_shadow_root
-            .elements_from_point(x, y, None, self.document.has_browsing_context())
-            .iter()
-        {
+        let query_results = self.document_or_shadow_root.elements_from_point(
+            x,
+            y,
+            None,
+            self.document.has_browsing_context(),
+        );
+
+        let mut elements = Vec::with_capacity(query_results.len());
+        for e in query_results.iter() {
             let retargeted_node = e.upcast::<EventTarget>().retarget(self.upcast());
             if let Some(element) = retargeted_node.downcast::<Element>().map(DomRoot::from_ref) {
                 elements.push(element);


### PR DESCRIPTION
💡 **What**: Replaced `.flat_map().collect()` and `Vec::new()` iterations with explicit `Vec::with_capacity()` pre-allocations in `components/script/dom/documentorshadowroot.rs` and `components/script/dom/shadowroot.rs`.

🎯 **Why**: In Rust, iterator chains involving `flat_map` or `filter_map` obscure the underlying size hints. This forces `collect()` to fall back to generic resizing policies, causing allocation churn (repeated heap reallocations) in hot DOM querying paths. By explicitly pre-allocating the vector using known upper bounds (`nodes.len() + 1` and `query_results.len()`), we guarantee only a single heap allocation occurs.

📊 **Impact**: Reduces $O(\log n)$ memory reallocations to $O(1)$ allocations per `elements_from_point` query. This speeds up intensive layout hit testing loops by avoiding heap fragmentation and allocator lock contention.

🔬 **Measurement**: Verify via CPU/memory profiling on dense page elements. Can be partially validated by successfully compiling `layout_api` and running cargo checks.

---
*PR created automatically by Jules for task [4629551319298545613](https://jules.google.com/task/4629551319298545613) started by @RingCanary*