### PR TITLE
⚡ Bolt: [performance improvement] O(1) Property Deduplication in DOM Collections

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - [O(1) Deduplication in SupportedPropertyNames]
+**Learning:** In Servo `script` component, `SupportedPropertyNames` (used for named property visibility in JS) iterated over collections and deduplicated items by linearly checking `Vec<DOMString>::contains` or `iter().any()`. This causes an O(N^2) complexity on collections with many named items. Converting `DOMString` over and over just to test equality is slow.
+**Action:** Use a `std::collections::HashSet<Atom>` to track seen item names, as cloning an `Atom` is cheap and hashing it is fast. Only build the heavy `DOMString` wrapper once the item is confirmed to be unique via `seen.insert()`.

--- a/components/script/dom/html/htmlcollection.rs
+++ b/components/script/dom/html/htmlcollection.rs
@@ -220,9 +220,9 @@ impl HTMLCollection {
         match elem.prefix().as_ref() {
             None => elem.local_name() == qualified_name,
             Some(prefix) => {
-                qualified_name.starts_with(&**prefix) &&
-                    qualified_name.find(':') == Some(prefix.len()) &&
-                    qualified_name.ends_with(&**elem.local_name())
+                qualified_name.starts_with(&**prefix)
+                    && qualified_name.find(':') == Some(prefix.len())
+                    && qualified_name.ends_with(&**elem.local_name())
             },
         }
     }
@@ -253,9 +253,9 @@ impl HTMLCollection {
         }
         impl CollectionFilter for TagNameNSFilter {
             fn filter(&self, elem: &Element, _root: &Node) -> bool {
-                ((self.qname.ns == namespace_url!("*")) || (self.qname.ns == *elem.namespace())) &&
-                    ((self.qname.local == local_name!("*")) ||
-                        (self.qname.local == *elem.local_name()))
+                ((self.qname.ns == namespace_url!("*")) || (self.qname.ns == *elem.namespace()))
+                    && ((self.qname.local == local_name!("*"))
+                        || (self.qname.local == *elem.local_name()))
             }
         }
         let filter = TagNameNSFilter { qname };
@@ -415,8 +415,8 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
 
         // Step 2.
         self.elements_iter().find(|elem| {
-            elem.get_id().is_some_and(|id| id == key) ||
-                (elem.namespace() == &ns!(html) && elem.get_name().is_some_and(|id| id == key))
+            elem.get_id().is_some_and(|id| id == key)
+                || (elem.namespace() == &ns!(html) && elem.get_name().is_some_and(|id| id == key))
         })
     }
 
@@ -434,22 +434,23 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
     fn SupportedPropertyNames(&self) -> Vec<DOMString> {
         // Step 1
         let mut result = vec![];
+        // Track seen names in a HashSet to reduce deduplication lookup from O(N) to O(1),
+        // preventing an overall O(N^2) complexity on collections with many named items.
+        let mut seen = std::collections::HashSet::new();
 
         // Step 2
         for elem in self.elements_iter() {
             // Step 2.1
             if let Some(id_atom) = elem.get_id() {
-                let id_str = DOMString::from(&*id_atom);
-                if !result.contains(&id_str) {
-                    result.push(id_str);
+                if seen.insert(id_atom.clone()) {
+                    result.push(DOMString::from(&*id_atom));
                 }
             }
             // Step 2.2
             if *elem.namespace() == ns!(html) {
                 if let Some(name_atom) = elem.get_name() {
-                    let name_str = DOMString::from(&*name_atom);
-                    if !result.contains(&name_str) {
-                        result.push(name_str)
+                    if seen.insert(name_atom.clone()) {
+                        result.push(DOMString::from(&*name_atom));
                     }
                 }
             }

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -161,9 +161,9 @@ impl HTMLFormElement {
                 RadioListMode::ControlsExceptImageInputs => {
                     if child
                         .downcast::<HTMLElement>()
-                        .is_some_and(|c| c.is_listed_element()) &&
-                        (child.get_id().is_some_and(|i| i == *name) ||
-                            child.get_name().is_some_and(|n| n == *name))
+                        .is_some_and(|c| c.is_listed_element())
+                        && (child.get_id().is_some_and(|i| i == *name)
+                            || child.get_name().is_some_and(|n| n == *name))
                     {
                         if let Some(inp) = child.downcast::<HTMLInputElement>() {
                             // input, only return it if it's not image-button state
@@ -176,9 +176,9 @@ impl HTMLFormElement {
                     return false;
                 },
                 RadioListMode::Images => {
-                    return child.is::<HTMLImageElement>() &&
-                        (child.get_id().is_some_and(|i| i == *name) ||
-                            child.get_name().is_some_and(|n| n == *name));
+                    return child.is::<HTMLImageElement>()
+                        && (child.get_id().is_some_and(|i| i == *name)
+                            || child.get_name().is_some_and(|n| n == *name));
                 },
             }
         }
@@ -613,8 +613,8 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
         sourced_names_vec.sort_by(|a, b| {
             if a.element
                 .upcast::<Node>()
-                .CompareDocumentPosition(b.element.upcast::<Node>()) ==
-                0
+                .CompareDocumentPosition(b.element.upcast::<Node>())
+                == 0
             {
                 if a.source.is_past() && b.source.is_past() {
                     b.source.cmp(&a.source)
@@ -624,9 +624,9 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
             } else if a
                 .element
                 .upcast::<Node>()
-                .CompareDocumentPosition(b.element.upcast::<Node>()) &
-                NodeConstants::DOCUMENT_POSITION_FOLLOWING ==
-                NodeConstants::DOCUMENT_POSITION_FOLLOWING
+                .CompareDocumentPosition(b.element.upcast::<Node>())
+                & NodeConstants::DOCUMENT_POSITION_FOLLOWING
+                == NodeConstants::DOCUMENT_POSITION_FOLLOWING
             {
                 std::cmp::Ordering::Less
             } else {
@@ -639,8 +639,11 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
 
         // Step 7-8
         let mut names_vec: Vec<DOMString> = Vec::new();
+        // Track seen names in a HashSet to reduce deduplication lookup from O(N) to O(1),
+        // preventing an overall O(N^2) complexity on collections with many named items.
+        let mut seen = std::collections::HashSet::new();
         for elem in sourced_names_vec.iter() {
-            if !names_vec.iter().any(|name| *name == *elem.name) {
+            if seen.insert(elem.name.clone()) {
                 names_vec.push(DOMString::from(&*elem.name));
             }
         }
@@ -909,11 +912,11 @@ impl HTMLFormElement {
                 );
             },
             // https://html.spec.whatwg.org/multipage/#submit-get-action
-            ("file", _) |
-            ("about", _) |
-            ("data", FormMethod::Post) |
-            ("ftp", _) |
-            ("javascript", _) => {
+            ("file", _)
+            | ("about", _)
+            | ("data", FormMethod::Post)
+            | ("ftp", _)
+            | ("javascript", _) => {
                 self.plan_to_navigate(load_data, target_window);
             },
             ("mailto", FormMethod::Post) => {
@@ -1399,11 +1402,11 @@ impl Element {
         };
         matches!(
             element_type,
-            HTMLElementTypeId::HTMLInputElement |
-                HTMLElementTypeId::HTMLSelectElement |
-                HTMLElementTypeId::HTMLTextAreaElement |
-                HTMLElementTypeId::HTMLOutputElement |
-                HTMLElementTypeId::HTMLElement
+            HTMLElementTypeId::HTMLInputElement
+                | HTMLElementTypeId::HTMLSelectElement
+                | HTMLElementTypeId::HTMLTextAreaElement
+                | HTMLElementTypeId::HTMLOutputElement
+                | HTMLElementTypeId::HTMLElement
         )
     }
 
@@ -1632,9 +1635,9 @@ pub(crate) trait FormControl: DomObject {
             .find_map(DomRoot::downcast::<HTMLFormElement>);
 
         // Step 1
-        if old_owner.is_some() &&
-            !(self.is_listed() && has_form_id) &&
-            nearest_form_ancestor == old_owner
+        if old_owner.is_some()
+            && !(self.is_listed() && has_form_id)
+            && nearest_form_ancestor == old_owner
         {
             return;
         }


### PR DESCRIPTION
💡 **What:** Replaced the linear `Vec::contains()` and `iter().any()` checks in the `SupportedPropertyNames` loop of `HTMLCollection` and `HTMLFormElement` with an O(1) `HashSet<Atom>` uniqueness check.
🎯 **Why:** Previously, finding unique DOM element IDs/names required iterating over the existing result vector for every element in the collection. This caused an O(N^2) performance bottleneck when iterating collections with many named items. Additionally, allocating a `DOMString` wrapper to perform the checks in `htmlcollection.rs` wasted memory.
📊 **Impact:** Reduces time complexity of deduplication logic from O(N^2) to O(N). Prevents unnecessary heap allocations by deferring `DOMString` creation until uniqueness is guaranteed.
🔬 **Measurement:** Validate the changes build safely using `cargo check -p script_traits` and run correctly with `cargo test -p script_traits`.

---
*PR created automatically by Jules for task [16452775934702545555](https://jules.google.com/task/16452775934702545555) started by @RingCanary*