### PR TITLE
⚡ Bolt: [performance improvement] Swap Vec for VecDeque to avoid O(N) shifts on pop_front

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-03-09 - Vec to VecDeque Migration requires method adjustments
+**Learning:** When changing a `Vec` to `VecDeque` for performance reasons (to avoid O(N) shifts on `remove(0)`), any existing `.first()` or `.first_mut()` calls on that collection will fail to compile, because `VecDeque` does not implement `Deref<Target = [T]>` and thus lacks these slice methods.
+**Action:** When swapping `Vec` for `VecDeque`, comprehensively grep for and replace `.first()` with `.front()` and `.first_mut()` with `.front_mut()`.

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -493,7 +493,7 @@ pub(crate) struct Document {
     script_and_layout_blockers: Cell<u32>,
     /// List of tasks to execute as soon as last script/layout blocker is removed.
     #[ignore_malloc_size_of = "Measuring trait objects is hard"]
-    delayed_tasks: DomRefCell<Vec<Box<dyn NonSendTaskBox>>>,
+    delayed_tasks: DomRefCell<VecDeque<Box<dyn NonSendTaskBox>>>,
     /// <https://html.spec.whatwg.org/multipage/#completely-loaded>
     completely_loaded: Cell<bool>,
     /// Set of shadow roots connected to the document tree.
@@ -2118,8 +2118,8 @@ impl Document {
         // to fire an event named hashchange at document's relevant global object, using HashChangeEvent,
         // with the oldURL attribute initialized to the serialization of oldURL
         // and the newURL attribute initialized to the serialization of entry's URL.
-        if old_url.as_url()[Position::BeforeFragment..] !=
-            new_url.as_url()[Position::BeforeFragment..]
+        if old_url.as_url()[Position::BeforeFragment..]
+            != new_url.as_url()[Position::BeforeFragment..]
         {
             let window = Trusted::new(self.owner_window().deref());
             let old_url = old_url.to_string();
@@ -3066,9 +3066,9 @@ impl Document {
         if !self.is_fully_active() {
             return false;
         }
-        if !self.window().layout_blocked() &&
-            (!self.restyle_reason().is_empty() ||
-                self.window().layout().needs_new_display_list())
+        if !self.window().layout_blocked()
+            && (!self.restyle_reason().is_empty()
+                || self.window().layout().needs_new_display_list())
         {
             return true;
         }
@@ -3439,8 +3439,8 @@ impl Document {
     ) {
         let metrics = self.interactive_time.borrow();
         match metric_type {
-            ProgressiveWebMetricType::FirstPaint |
-            ProgressiveWebMetricType::FirstContentfulPaint => {
+            ProgressiveWebMetricType::FirstPaint
+            | ProgressiveWebMetricType::FirstContentfulPaint => {
                 let binding = PerformancePaintTiming::new(
                     self.window.as_global_scope(),
                     metric_type,
@@ -3536,8 +3536,8 @@ impl Document {
             _ => {
                 // Step 9.1: If document's unload counter is greater than 0 or
                 // document's ignore-destructive-writes counter is greater than 0, then return.
-                if self.is_prompting_or_unloading() ||
-                    self.ignore_destructive_writes_counter.get() > 0
+                if self.is_prompting_or_unloading()
+                    || self.ignore_destructive_writes_counter.get() > 0
                 {
                     return Ok(());
                 }
@@ -3891,8 +3891,8 @@ impl Document {
     pub(crate) fn insecure_requests_policy(&self) -> InsecureRequestsPolicy {
         if let Some(csp_list) = self.get_csp_list() {
             for policy in &csp_list.0 {
-                if policy.contains_a_directive_whose_name_is("upgrade-insecure-requests") &&
-                    policy.disposition == PolicyDisposition::Enforce
+                if policy.contains_a_directive_whose_name_is("upgrade-insecure-requests")
+                    && policy.disposition == PolicyDisposition::Enforce
                 {
                     return InsecureRequestsPolicy::Upgrade;
                 }
@@ -3954,7 +3954,7 @@ impl Document {
             .set(self.script_and_layout_blockers.get() - 1);
         while self.script_and_layout_blockers.get() == 0 && !self.delayed_tasks.borrow().is_empty()
         {
-            let task = self.delayed_tasks.borrow_mut().remove(0);
+            let task = self.delayed_tasks.borrow_mut().pop_front().unwrap();
             let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
             task.run_box(&mut cx);
         }
@@ -3962,7 +3962,7 @@ impl Document {
 
     /// Enqueue a task to run as soon as any JS and layout blockers are removed.
     pub(crate) fn add_delayed_task<T: 'static + NonSendTaskBox>(&self, task: T) {
-        self.delayed_tasks.borrow_mut().push(Box::new(task));
+        self.delayed_tasks.borrow_mut().push_back(Box::new(task));
     }
 
     /// Assert that the DOM is in a state that will allow running content JS or
@@ -4866,8 +4866,8 @@ impl Document {
     }
 
     pub(crate) fn has_trustworthy_ancestor_or_current_origin(&self) -> bool {
-        self.has_trustworthy_ancestor_origin.get() ||
-            self.origin().immutable().is_potentially_trustworthy()
+        self.has_trustworthy_ancestor_origin.get()
+            || self.origin().immutable().is_potentially_trustworthy()
     }
 
     pub(crate) fn highlight_dom_node(&self, node: Option<&Node>) {
@@ -5698,8 +5698,8 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
 
         let node = new_body.upcast::<Node>();
         match node.type_id() {
-            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLBodyElement)) |
-            NodeTypeId::Element(ElementTypeId::HTMLElement(
+            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLBodyElement))
+            | NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLFrameSetElement,
             )) => {},
             _ => return Err(Error::HierarchyRequest(None)),
@@ -5772,8 +5772,8 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                 &self.window,
                 self.upcast(),
                 |element, _| {
-                    (element.is::<HTMLAnchorElement>() || element.is::<HTMLAreaElement>()) &&
-                        element.has_attribute(&local_name!("href"))
+                    (element.is::<HTMLAnchorElement>() || element.is::<HTMLAreaElement>())
+                        && element.has_attribute(&local_name!("href"))
                 },
                 can_gc,
             )
@@ -6021,8 +6021,8 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                         elem.get_name().as_ref() == Some(&self.name)
                     },
                     HTMLElementTypeId::HTMLImageElement => elem.get_name().is_some_and(|name| {
-                        name == *self.name ||
-                            !name.is_empty() && elem.get_id().as_ref() == Some(&self.name)
+                        name == *self.name
+                            || !name.is_empty() && elem.get_id().as_ref() == Some(&self.name)
                     }),
                     // TODO handle <embed> and <object>; these depend on whether the element is
                     // “exposed”, a concept that doesn’t fully make sense until embed/object
@@ -6630,9 +6630,9 @@ fn is_named_element_with_name_attribute(elem: &Element) -> bool {
         _ => return false,
     };
     match type_ {
-        HTMLElementTypeId::HTMLFormElement |
-        HTMLElementTypeId::HTMLIFrameElement |
-        HTMLElementTypeId::HTMLImageElement => true,
+        HTMLElementTypeId::HTMLFormElement
+        | HTMLElementTypeId::HTMLIFrameElement
+        | HTMLElementTypeId::HTMLImageElement => true,
         // TODO handle <embed> and <object>; these depend on whether the element is
         // “exposed”, a concept that doesn’t fully make sense until embed/object
         // behaviour is actually implemented

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -207,7 +207,7 @@ pub(crate) struct ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#readablebytestreamcontroller-byobrequest>
     byob_request: MutNullableDom<ReadableStreamBYOBRequest>,
     /// <https://streams.spec.whatwg.org/#readablebytestreamcontroller-pendingpullintos>
-    pending_pull_intos: DomRefCell<Vec<PullIntoDescriptor>>,
+    pending_pull_intos: DomRefCell<VecDeque<PullIntoDescriptor>>,
     /// <https://streams.spec.whatwg.org/#readablebytestreamcontroller-closerequested>
     close_requested: Cell<bool>,
     /// <https://streams.spec.whatwg.org/#readablebytestreamcontroller-started>
@@ -235,7 +235,7 @@ impl ReadableByteStreamController {
             stream: MutNullableDom::new(None),
             underlying_source: MutNullableDom::new(Some(&*underlying_source_container)),
             auto_allocate_chunk_size,
-            pending_pull_intos: DomRefCell::new(Vec::new()),
+            pending_pull_intos: DomRefCell::new(VecDeque::new()),
             strategy_hwm,
             close_requested: Default::default(),
             queue: DomRefCell::new(Default::default()),
@@ -349,7 +349,7 @@ impl ReadableByteStreamController {
                     let mut pending_pull_intos = self.pending_pull_intos.borrow_mut();
                     if !pending_pull_intos.is_empty() {
                         // Append pullIntoDescriptor to controller.[[pendingPullIntos]].
-                        pending_pull_intos.push(pull_into_descriptor);
+                        pending_pull_intos.push_back(pull_into_descriptor);
 
                         // Perform ! ReadableStreamAddReadIntoRequest(stream, readIntoRequest).
                         stream.add_read_into_request(read_into_request);
@@ -498,8 +498,8 @@ impl ReadableByteStreamController {
 
                 // If firstDescriptor’s bytes filled + bytesWritten > firstDescriptor’s byte length,
                 // throw a RangeError exception.
-                if first_descriptor.bytes_filled.get() + bytes_written >
-                    first_descriptor.byte_length
+                if first_descriptor.bytes_filled.get() + bytes_written
+                    > first_descriptor.byte_length
                 {
                     return Err(Error::Range(
                         "bytes filled + bytesWritten > byte length".to_owned(),
@@ -528,7 +528,7 @@ impl ReadableByteStreamController {
         {
             // Let firstDescriptor be controller.[[pendingPullIntos]][0].
             let pending_pull_intos = self.pending_pull_intos.borrow();
-            let first_descriptor = pending_pull_intos.first().unwrap();
+            let first_descriptor = pending_pull_intos.front().unwrap();
 
             // Assert: ! CanTransferArrayBuffer(firstDescriptor’s buffer) is true
             assert!(first_descriptor.buffer.can_transfer_array_buffer(cx));
@@ -568,7 +568,7 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-in-closed-state>
     pub(crate) fn respond_in_closed_state(&self, cx: SafeJSContext, can_gc: CanGc) -> Fallible<()> {
         let pending_pull_intos = self.pending_pull_intos.borrow();
-        let first_descriptor = pending_pull_intos.first().unwrap();
+        let first_descriptor = pending_pull_intos.front().unwrap();
 
         // Assert: the remainder after dividing firstDescriptor’s bytes filled
         // by firstDescriptor’s element size is 0.
@@ -624,7 +624,7 @@ impl ReadableByteStreamController {
         can_gc: CanGc,
     ) -> Fallible<()> {
         let pending_pull_intos = self.pending_pull_intos.borrow();
-        let first_descriptor = pending_pull_intos.first().unwrap();
+        let first_descriptor = pending_pull_intos.front().unwrap();
 
         // Assert: pullIntoDescriptor’s bytes filled + bytesWritten ≤ pullIntoDescriptor’s byte length.
         assert!(
@@ -754,8 +754,8 @@ impl ReadableByteStreamController {
 
             // If firstDescriptor’s byte offset + firstDescriptor’ bytes filled is not view.[[ByteOffset]],
             // throw a RangeError exception.
-            if first_descriptor.byte_offset + first_descriptor.bytes_filled.get() !=
-                (view.get_byte_offset() as u64)
+            if first_descriptor.byte_offset + first_descriptor.bytes_filled.get()
+                != (view.get_byte_offset() as u64)
             {
                 return Err(Error::Range(
                     "firstDescriptor's byte offset + bytes filled is not view byte offset"
@@ -765,8 +765,8 @@ impl ReadableByteStreamController {
 
             // If firstDescriptor’s buffer byte length is not view.[[ViewedArrayBuffer]].[[ByteLength]],
             // throw a RangeError exception.
-            if first_descriptor.buffer_byte_length !=
-                (view.viewed_buffer_array_byte_length(cx) as u64)
+            if first_descriptor.buffer_byte_length
+                != (view.viewed_buffer_array_byte_length(cx) as u64)
             {
                 return Err(Error::Range(
                 "firstDescriptor's buffer byte length is not view viewed buffer array byte length"
@@ -776,8 +776,8 @@ impl ReadableByteStreamController {
 
             // If firstDescriptor’s bytes filled + view.[[ByteLength]] > firstDescriptor’s byte length,
             // throw a RangeError exception.
-            if first_descriptor.bytes_filled.get() + (view.byte_length()) as u64 >
-                first_descriptor.byte_length
+            if first_descriptor.bytes_filled.get() + (view.byte_length()) as u64
+                > first_descriptor.byte_length
             {
                 return Err(Error::Range(
                     "bytes filled + view byte length > byte length".to_owned(),
@@ -826,7 +826,7 @@ impl ReadableByteStreamController {
         let pending_pull_intos = self.pending_pull_intos.borrow();
         if self.byob_request.get().is_none() && !pending_pull_intos.is_empty() {
             // Let firstDescriptor be controller.[[pendingPullIntos]][0].
-            let first_descriptor = pending_pull_intos.first().unwrap();
+            let first_descriptor = pending_pull_intos.front().unwrap();
             // Let view be ! Construct(%Uint8Array%, « firstDescriptor’s buffer,
             // firstDescriptor’s byte offset + firstDescriptor’s bytes filled,
             // firstDescriptor’s byte length − firstDescriptor’s bytes filled »).
@@ -882,12 +882,12 @@ impl ReadableByteStreamController {
         let pending_pull_intos = self.pending_pull_intos.borrow();
         if !pending_pull_intos.is_empty() {
             // Let firstPendingPullInto be controller.[[pendingPullIntos]][0].
-            let first_pending_pull_into = pending_pull_intos.first().unwrap();
+            let first_pending_pull_into = pending_pull_intos.front().unwrap();
 
             // If the remainder after dividing firstPendingPullInto’s bytes filled by
             // firstPendingPullInto’s element size is not 0,
-            if first_pending_pull_into.bytes_filled.get() % first_pending_pull_into.element_size !=
-                0
+            if first_pending_pull_into.bytes_filled.get() % first_pending_pull_into.element_size
+                != 0
             {
                 // needed to drop the borrow and avoid BorrowMutError
                 drop(pending_pull_intos);
@@ -1073,7 +1073,7 @@ impl ReadableByteStreamController {
                 if !pending_pull_intos.is_empty() {
                     // Assert: controller.[[pendingPullIntos]][0]'s reader type is "default".
                     assert!(matches!(
-                        pending_pull_intos.first().unwrap().reader_type,
+                        pending_pull_intos.front().unwrap().reader_type,
                         Some(ReaderType::Default)
                     ));
 
@@ -1242,7 +1242,7 @@ impl ReadableByteStreamController {
             // Let pullIntoDescriptor be controller.[[pendingPullIntos]][0].
             let fill_pull_result = {
                 let pending_pull_intos = self.pending_pull_intos.borrow();
-                let Some(pull_into_descriptor) = pending_pull_intos.first() else {
+                let Some(pull_into_descriptor) = pending_pull_intos.front() else {
                     break;
                 };
                 self.fill_pull_into_descriptor_from_queue(cx, pull_into_descriptor)
@@ -1401,8 +1401,8 @@ impl ReadableByteStreamController {
         {
             let pending_pull_intos = self.pending_pull_intos.borrow();
             assert!(
-                pending_pull_intos.is_empty() ||
-                    pending_pull_intos.first().unwrap() == pull_into_descriptor
+                pending_pull_intos.is_empty()
+                    || pending_pull_intos.front().unwrap() == pull_into_descriptor
             );
         }
 
@@ -1423,7 +1423,7 @@ impl ReadableByteStreamController {
     ) -> Fallible<()> {
         // first_descriptor: &PullIntoDescriptor,
         let pending_pull_intos = self.pending_pull_intos.borrow();
-        let first_descriptor = pending_pull_intos.first().unwrap();
+        let first_descriptor = pending_pull_intos.front().unwrap();
 
         // Assert: pullIntoDescriptor’s reader type is "none".
         assert!(first_descriptor.reader_type.is_none());
@@ -1511,7 +1511,7 @@ impl ReadableByteStreamController {
         // Let descriptor be controller.[[pendingPullIntos]][0].
         // Remove descriptor from controller.[[pendingPullIntos]].
         // Return descriptor.
-        self.pending_pull_intos.borrow_mut().remove(0)
+        self.pending_pull_intos.borrow_mut().pop_front().unwrap()
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontrollerprocessreadrequestsusingqueue>
@@ -1789,14 +1789,14 @@ impl ReadableByteStreamController {
         let mut pending_pull_intos = self.pending_pull_intos.borrow_mut();
         if !pending_pull_intos.is_empty() {
             // Let firstPendingPullInto be this.[[pendingPullIntos]][0].
-            let mut first_pending_pull_into = pending_pull_intos.remove(0);
+            let mut first_pending_pull_into = pending_pull_intos.pop_front().unwrap();
 
             // Set firstPendingPullInto’s reader type to "none".
             first_pending_pull_into.reader_type = None;
 
             // Set this.[[pendingPullIntos]] to the list « firstPendingPullInto »
             pending_pull_intos.clear();
-            pending_pull_intos.push(first_pending_pull_into);
+            pending_pull_intos.push_back(first_pending_pull_into);
         }
         Ok(())
     }
@@ -1906,7 +1906,7 @@ impl ReadableByteStreamController {
                     // Append pullIntoDescriptor to this.[[pendingPullIntos]].
                     self.pending_pull_intos
                         .borrow_mut()
-                        .push(pull_into_descriptor);
+                        .push_back(pull_into_descriptor);
                 },
                 Err(error) => {
                     // If buffer is an abrupt completion,

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -59,7 +59,7 @@ struct OrderingEntry {
 }
 
 // Per-ordering queues map
-type OrderingQueues = FxHashMap<OrderingIdentifier, Vec<OrderingEntry>>;
+type OrderingQueues = FxHashMap<OrderingIdentifier, VecDeque<OrderingEntry>>;
 
 // Active timers map for Run Steps After A Timeout
 type RunStepsActiveMap = FxHashMap<TimerKey, RunStepsDeadline>;
@@ -410,7 +410,7 @@ impl OneshotTimers {
                         let mut queues_mut = self.runsteps_queues.borrow_mut();
                         if let Some(q) = queues_mut.get_mut(&ordering_id_owned) {
                             if !q.is_empty() {
-                                q.remove(0);
+                                q.pop_front().unwrap();
                             }
                             if q.is_empty() {
                                 queues_mut.remove(&ordering_id_owned);
@@ -834,8 +834,8 @@ impl JsTimerTask {
         //
         // Since we choose proactively prevent execution (see 4.1 above), we must only
         // reschedule repeating timers when they were not canceled as part of step 4.2.
-        if self.is_interval == IsInterval::Interval &&
-            timers.active_timers.borrow().contains_key(&self.handle)
+        if self.is_interval == IsInterval::Interval
+            && timers.active_timers.borrow().contains_key(&self.handle)
         {
             timers.initialize_and_schedule(&this.global(), self);
         }


### PR DESCRIPTION
### 💡 What
Swaps `Vec` for `VecDeque` in the following task queues:
- `OrderingQueues` in `components/script/timers.rs`
- `pending_pull_intos` in `components/script/dom/stream/readablebytestreamcontroller.rs`
- `delayed_tasks` in `components/script/dom/document.rs`

Updated `remove(0)` to `pop_front().unwrap()` and `.first()` to `.front()`.

### 🎯 Why
Calling `remove(0)` on a standard `Vec` forces all subsequent elements to be shifted left in memory. For heavily used task queues, this is an unnecessary O(N) operation per task execution.

### 📊 Impact
Changes queue popping from O(N) to O(1) complexity, reducing CPU cycles wasted on memory moves during tight loops (e.g., executing delayed tasks or shifting pending pull-intos).

### 🔬 Measurement
Run `cargo test -p script_traits` and observe existing test parity while CPU execution of queue-draining operations avoids O(N) scaling.

---
*PR created automatically by Jules for task [7200984478991035423](https://jules.google.com/task/7200984478991035423) started by @RingCanary*