### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2025-03-01 - Avoid allocating string on empty check & HashSet insertion over Iterator::any
+
+**Learning:** `Atom`s in Servo can be checked for emptiness directly using `.is_empty()` instead of `.to_string().is_empty()` which triggers a heap allocation. Furthermore, deduplicating an array of `Atom`s or `DOMString`s is O(N^2) using `!vec.iter().any(|v| *v == x)`, but using a `HashSet` allows O(1) membership checks (O(N) overall), and storing references to the Atom `seen.insert(&elem.name)` instead of `.clone()`ing them into the HashSet is even faster (zero-cost abstraction).
+
+**Action:** When filtering or deduplicating data, use `HashSet` with references `&T` to prevent unnecessary allocations, and ensure simple property checks (like emptiness) use the native implementations of the types rather than coercing them into strings first.

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -161,9 +161,9 @@ impl HTMLFormElement {
                 RadioListMode::ControlsExceptImageInputs => {
                     if child
                         .downcast::<HTMLElement>()
-                        .is_some_and(|c| c.is_listed_element()) &&
-                        (child.get_id().is_some_and(|i| i == *name) ||
-                            child.get_name().is_some_and(|n| n == *name))
+                        .is_some_and(|c| c.is_listed_element())
+                        && (child.get_id().is_some_and(|i| i == *name)
+                            || child.get_name().is_some_and(|n| n == *name))
                     {
                         if let Some(inp) = child.downcast::<HTMLInputElement>() {
                             // input, only return it if it's not image-button state
@@ -176,9 +176,9 @@ impl HTMLFormElement {
                     return false;
                 },
                 RadioListMode::Images => {
-                    return child.is::<HTMLImageElement>() &&
-                        (child.get_id().is_some_and(|i| i == *name) ||
-                            child.get_name().is_some_and(|n| n == *name));
+                    return child.is::<HTMLImageElement>()
+                        && (child.get_id().is_some_and(|i| i == *name)
+                            || child.get_name().is_some_and(|n| n == *name));
                 },
             }
         }
@@ -613,8 +613,8 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
         sourced_names_vec.sort_by(|a, b| {
             if a.element
                 .upcast::<Node>()
-                .CompareDocumentPosition(b.element.upcast::<Node>()) ==
-                0
+                .CompareDocumentPosition(b.element.upcast::<Node>())
+                == 0
             {
                 if a.source.is_past() && b.source.is_past() {
                     b.source.cmp(&a.source)
@@ -624,9 +624,9 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
             } else if a
                 .element
                 .upcast::<Node>()
-                .CompareDocumentPosition(b.element.upcast::<Node>()) &
-                NodeConstants::DOCUMENT_POSITION_FOLLOWING ==
-                NodeConstants::DOCUMENT_POSITION_FOLLOWING
+                .CompareDocumentPosition(b.element.upcast::<Node>())
+                & NodeConstants::DOCUMENT_POSITION_FOLLOWING
+                == NodeConstants::DOCUMENT_POSITION_FOLLOWING
             {
                 std::cmp::Ordering::Less
             } else {
@@ -635,12 +635,17 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
         });
 
         // Step 6
-        sourced_names_vec.retain(|sn| !sn.name.to_string().is_empty());
+        // Optimization: Avoid `to_string()` heap allocation for empty check
+        sourced_names_vec.retain(|sn| !sn.name.is_empty());
 
         // Step 7-8
-        let mut names_vec: Vec<DOMString> = Vec::new();
+        // Optimization: Pre-allocate capacity to avoid O(N) reallocation overhead
+        let mut names_vec: Vec<DOMString> = Vec::with_capacity(sourced_names_vec.len());
+        let mut seen = std::collections::HashSet::with_capacity(sourced_names_vec.len());
         for elem in sourced_names_vec.iter() {
-            if !names_vec.iter().any(|name| *name == *elem.name) {
+            // Optimization: Replace O(N^2) `.any()` linear scan with O(1) HashSet lookup
+            // Store references (`&elem.name`) to avoid cloning the Atom
+            if seen.insert(&elem.name) {
                 names_vec.push(DOMString::from(&*elem.name));
             }
         }
@@ -909,11 +914,11 @@ impl HTMLFormElement {
                 );
             },
             // https://html.spec.whatwg.org/multipage/#submit-get-action
-            ("file", _) |
-            ("about", _) |
-            ("data", FormMethod::Post) |
-            ("ftp", _) |
-            ("javascript", _) => {
+            ("file", _)
+            | ("about", _)
+            | ("data", FormMethod::Post)
+            | ("ftp", _)
+            | ("javascript", _) => {
                 self.plan_to_navigate(load_data, target_window);
             },
             ("mailto", FormMethod::Post) => {
@@ -1399,11 +1404,11 @@ impl Element {
         };
         matches!(
             element_type,
-            HTMLElementTypeId::HTMLInputElement |
-                HTMLElementTypeId::HTMLSelectElement |
-                HTMLElementTypeId::HTMLTextAreaElement |
-                HTMLElementTypeId::HTMLOutputElement |
-                HTMLElementTypeId::HTMLElement
+            HTMLElementTypeId::HTMLInputElement
+                | HTMLElementTypeId::HTMLSelectElement
+                | HTMLElementTypeId::HTMLTextAreaElement
+                | HTMLElementTypeId::HTMLOutputElement
+                | HTMLElementTypeId::HTMLElement
         )
     }
 
@@ -1632,9 +1637,9 @@ pub(crate) trait FormControl: DomObject {
             .find_map(DomRoot::downcast::<HTMLFormElement>);
 
         // Step 1
-        if old_owner.is_some() &&
-            !(self.is_listed() && has_form_id) &&
-            nearest_form_ancestor == old_owner
+        if old_owner.is_some()
+            && !(self.is_listed() && has_form_id)
+            && nearest_form_ancestor == old_owner
         {
             return;
         }


### PR DESCRIPTION
💡 What:
1. Removed `to_string().is_empty()` in favor of direct `.is_empty()` check on `Atom`.
2. Pre-allocated `names_vec` using `Vec::with_capacity` based on the length of `sourced_names_vec`.
3. Replaced an O(N^2) `.iter().any(...)` check with an O(1) `HashSet` lookup, specifically storing references `&elem.name` to avoid `.clone()`-ing the underlying `Atom`.

🎯 Why:
The `SupportedPropertyNames` operation in `HTMLFormElement` deduplicates elements by checking against the previous collected names. In a form with many elements, the linear `.any` check becomes a noticeable performance bottleneck due to its O(N^2) time complexity. Furthermore, stringifying simply to check for emptiness introduces unneeded allocation churn.

📊 Impact:
- Reduces string allocations to zero for the emptiness check.
- Improves deduplication from O(N^2) to O(N).
- Eliminates repeated dynamic array reallocation during insertion via `with_capacity`.

🔬 Measurement:
Run `cargo test -p script_traits` and observe existing tests continuing to pass. A microbenchmark against forms with hundreds of inputs would show significant reductions in execution time and memory allocations.

---
*PR created automatically by Jules for task [133295522113545899](https://jules.google.com/task/133295522113545899) started by @RingCanary*