### PR TITLE
⚡ Bolt: [performance improvement] Pre-allocate vectors in ElementsFromPoint

### DIFF
--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -207,16 +207,17 @@ impl DocumentOrShadowRoot {
         let nodes = self
             .window
             .elements_from_point_query(LayoutPoint::new(x, y), ElementsFromPointFlags::FindAll);
-        let mut elements: Vec<DomRoot<Element>> = nodes
-            .iter()
-            .flat_map(|result| {
-                // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
-                // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
-                let address = UntrustedNodeAddress(result.node.0 as *const c_void);
-                let node = unsafe { node::from_untrusted_node_address(address) };
-                DomRoot::downcast::<Element>(node)
-            })
-            .collect();
+        // Optimization: Pre-allocate `elements` vector with exact bounds to avoid O(N) reallocation overhead during loop insertion.
+        let mut elements: Vec<DomRoot<Element>> = Vec::with_capacity(nodes.len() + 1);
+        for result in nodes.iter() {
+            // SAFETY: This is safe because `Self::query_elements_from_point` has ensured that
+            // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
+            let address = UntrustedNodeAddress(result.node.0 as *const c_void);
+            let node = unsafe { node::from_untrusted_node_address(address) };
+            if let Some(element) = DomRoot::downcast::<Element>(node) {
+                elements.push(element);
+            }
+        }
 
         // Step 4
         if let Some(root_element) = document_element {
@@ -336,8 +337,8 @@ impl DocumentOrShadowRoot {
     ) {
         debug!("Adding named element {:p}: {:p} id={}", self, element, id);
         assert!(
-            element.upcast::<Node>().is_in_a_document_tree() ||
-                element.upcast::<Node>().is_in_a_shadow_tree()
+            element.upcast::<Node>().is_in_a_document_tree()
+                || element.upcast::<Node>().is_in_a_shadow_tree()
         );
         assert!(!id.is_empty());
         let mut id_map = id_map.borrow_mut();

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -402,12 +402,16 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     fn ElementsFromPoint(&self, x: Finite<f64>, y: Finite<f64>) -> Vec<DomRoot<Element>> {
         // Return the result of running the retargeting algorithm with context object
         // and the original result as input
-        let mut elements = Vec::new();
-        for e in self
-            .document_or_shadow_root
-            .elements_from_point(x, y, None, self.document.has_browsing_context())
-            .iter()
-        {
+        let source_elements = self.document_or_shadow_root.elements_from_point(
+            x,
+            y,
+            None,
+            self.document.has_browsing_context(),
+        );
+
+        // Optimization: Pre-allocate `elements` vector based on source element length to eliminate O(N) reallocation overhead.
+        let mut elements = Vec::with_capacity(source_elements.len());
+        for e in source_elements.iter() {
             let retargeted_node = e.upcast::<EventTarget>().retarget(self.upcast());
             if let Some(element) = retargeted_node.downcast::<Element>().map(DomRoot::from_ref) {
                 elements.push(element);


### PR DESCRIPTION
💡 **What:** 
Replaced dynamic `Vec::new()` and `flat_map().collect()` calls with explicit pre-allocation using `Vec::with_capacity()` in `components/script/dom/shadowroot.rs` and `components/script/dom/documentorshadowroot.rs`. Added explicit comments detailing the O-notation optimization.

🎯 **Why:** 
The previous implementations dynamically grew vectors during iteration. In `documentorshadowroot.rs`, `.flat_map().collect()` provided a vague size hint, leading to potential reallocation overhead. In `shadowroot.rs`, the vector was instantiated with `Vec::new()`, meaning multiple pushes could trigger multiple allocations depending on the number of matched nodes.

📊 **Impact:** 
Eliminates O(N) reallocation overhead. Vector bounds are now explicitly allocated based on the pre-queried length (`nodes.len() + 1` and `source_elements.len()`), turning insertions into purely O(1) operations.

🔬 **Measurement:** 
Run `cargo check -p script_traits` and `cargo test -p script_traits` to verify syntax and logic correctly compiles and passes.

---
*PR created automatically by Jules for task [17951488476227689685](https://jules.google.com/task/17951488476227689685) started by @RingCanary*