### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/components/script/dom/html/htmlcollection.rs
+++ b/components/script/dom/html/htmlcollection.rs
@@ -220,9 +220,9 @@ impl HTMLCollection {
         match elem.prefix().as_ref() {
             None => elem.local_name() == qualified_name,
             Some(prefix) => {
-                qualified_name.starts_with(&**prefix) &&
-                    qualified_name.find(':') == Some(prefix.len()) &&
-                    qualified_name.ends_with(&**elem.local_name())
+                qualified_name.starts_with(&**prefix)
+                    && qualified_name.find(':') == Some(prefix.len())
+                    && qualified_name.ends_with(&**elem.local_name())
             },
         }
     }
@@ -253,9 +253,9 @@ impl HTMLCollection {
         }
         impl CollectionFilter for TagNameNSFilter {
             fn filter(&self, elem: &Element, _root: &Node) -> bool {
-                ((self.qname.ns == namespace_url!("*")) || (self.qname.ns == *elem.namespace())) &&
-                    ((self.qname.local == local_name!("*")) ||
-                        (self.qname.local == *elem.local_name()))
+                ((self.qname.ns == namespace_url!("*")) || (self.qname.ns == *elem.namespace()))
+                    && ((self.qname.local == local_name!("*"))
+                        || (self.qname.local == *elem.local_name()))
             }
         }
         let filter = TagNameNSFilter { qname };
@@ -415,8 +415,8 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
 
         // Step 2.
         self.elements_iter().find(|elem| {
-            elem.get_id().is_some_and(|id| id == key) ||
-                (elem.namespace() == &ns!(html) && elem.get_name().is_some_and(|id| id == key))
+            elem.get_id().is_some_and(|id| id == key)
+                || (elem.namespace() == &ns!(html) && elem.get_name().is_some_and(|id| id == key))
         })
     }
 
@@ -434,22 +434,21 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
     fn SupportedPropertyNames(&self) -> Vec<DOMString> {
         // Step 1
         let mut result = vec![];
+        let mut seen = std::collections::HashSet::new();
 
         // Step 2
         for elem in self.elements_iter() {
             // Step 2.1
             if let Some(id_atom) = elem.get_id() {
-                let id_str = DOMString::from(&*id_atom);
-                if !result.contains(&id_str) {
-                    result.push(id_str);
+                if seen.insert(id_atom.clone()) {
+                    result.push(DOMString::from(&*id_atom));
                 }
             }
             // Step 2.2
             if *elem.namespace() == ns!(html) {
                 if let Some(name_atom) = elem.get_name() {
-                    let name_str = DOMString::from(&*name_atom);
-                    if !result.contains(&name_str) {
-                        result.push(name_str)
+                    if seen.insert(name_atom.clone()) {
+                        result.push(DOMString::from(&*name_atom));
                     }
                 }
             }

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -161,9 +161,9 @@ impl HTMLFormElement {
                 RadioListMode::ControlsExceptImageInputs => {
                     if child
                         .downcast::<HTMLElement>()
-                        .is_some_and(|c| c.is_listed_element()) &&
-                        (child.get_id().is_some_and(|i| i == *name) ||
-                            child.get_name().is_some_and(|n| n == *name))
+                        .is_some_and(|c| c.is_listed_element())
+                        && (child.get_id().is_some_and(|i| i == *name)
+                            || child.get_name().is_some_and(|n| n == *name))
                     {
                         if let Some(inp) = child.downcast::<HTMLInputElement>() {
                             // input, only return it if it's not image-button state
@@ -176,9 +176,9 @@ impl HTMLFormElement {
                     return false;
                 },
                 RadioListMode::Images => {
-                    return child.is::<HTMLImageElement>() &&
-                        (child.get_id().is_some_and(|i| i == *name) ||
-                            child.get_name().is_some_and(|n| n == *name));
+                    return child.is::<HTMLImageElement>()
+                        && (child.get_id().is_some_and(|i| i == *name)
+                            || child.get_name().is_some_and(|n| n == *name));
                 },
             }
         }
@@ -613,8 +613,8 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
         sourced_names_vec.sort_by(|a, b| {
             if a.element
                 .upcast::<Node>()
-                .CompareDocumentPosition(b.element.upcast::<Node>()) ==
-                0
+                .CompareDocumentPosition(b.element.upcast::<Node>())
+                == 0
             {
                 if a.source.is_past() && b.source.is_past() {
                     b.source.cmp(&a.source)
@@ -624,9 +624,9 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
             } else if a
                 .element
                 .upcast::<Node>()
-                .CompareDocumentPosition(b.element.upcast::<Node>()) &
-                NodeConstants::DOCUMENT_POSITION_FOLLOWING ==
-                NodeConstants::DOCUMENT_POSITION_FOLLOWING
+                .CompareDocumentPosition(b.element.upcast::<Node>())
+                & NodeConstants::DOCUMENT_POSITION_FOLLOWING
+                == NodeConstants::DOCUMENT_POSITION_FOLLOWING
             {
                 std::cmp::Ordering::Less
             } else {
@@ -638,9 +638,10 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
         sourced_names_vec.retain(|sn| !sn.name.to_string().is_empty());
 
         // Step 7-8
-        let mut names_vec: Vec<DOMString> = Vec::new();
+        let mut names_vec: Vec<DOMString> = Vec::with_capacity(sourced_names_vec.len());
+        let mut seen = std::collections::HashSet::with_capacity(sourced_names_vec.len());
         for elem in sourced_names_vec.iter() {
-            if !names_vec.iter().any(|name| *name == *elem.name) {
+            if seen.insert(elem.name.clone()) {
                 names_vec.push(DOMString::from(&*elem.name));
             }
         }
@@ -909,11 +910,11 @@ impl HTMLFormElement {
                 );
             },
             // https://html.spec.whatwg.org/multipage/#submit-get-action
-            ("file", _) |
-            ("about", _) |
-            ("data", FormMethod::Post) |
-            ("ftp", _) |
-            ("javascript", _) => {
+            ("file", _)
+            | ("about", _)
+            | ("data", FormMethod::Post)
+            | ("ftp", _)
+            | ("javascript", _) => {
                 self.plan_to_navigate(load_data, target_window);
             },
             ("mailto", FormMethod::Post) => {
@@ -1399,11 +1400,11 @@ impl Element {
         };
         matches!(
             element_type,
-            HTMLElementTypeId::HTMLInputElement |
-                HTMLElementTypeId::HTMLSelectElement |
-                HTMLElementTypeId::HTMLTextAreaElement |
-                HTMLElementTypeId::HTMLOutputElement |
-                HTMLElementTypeId::HTMLElement
+            HTMLElementTypeId::HTMLInputElement
+                | HTMLElementTypeId::HTMLSelectElement
+                | HTMLElementTypeId::HTMLTextAreaElement
+                | HTMLElementTypeId::HTMLOutputElement
+                | HTMLElementTypeId::HTMLElement
         )
     }
 
@@ -1632,9 +1633,9 @@ pub(crate) trait FormControl: DomObject {
             .find_map(DomRoot::downcast::<HTMLFormElement>);
 
         // Step 1
-        if old_owner.is_some() &&
-            !(self.is_listed() && has_form_id) &&
-            nearest_form_ancestor == old_owner
+        if old_owner.is_some()
+            && !(self.is_listed() && has_form_id)
+            && nearest_form_ancestor == old_owner
         {
             return;
         }

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -107,15 +107,17 @@ impl NamedNodeMapMethods<crate::DomTypeHolder> for NamedNodeMap {
 
     /// <https://heycam.github.io/webidl/#dfn-supported-property-names>
     fn SupportedPropertyNames(&self) -> Vec<DOMString> {
-        let mut names = vec![];
+        let attrs = self.owner.attrs();
+        let mut names = Vec::with_capacity(attrs.len());
+        let mut seen = std::collections::HashSet::with_capacity(attrs.len());
         let html_element_in_html_document = self.owner.html_element_in_html_document();
-        for attr in self.owner.attrs().iter() {
+        for attr in attrs.iter() {
             let s = &**attr.name();
             if html_element_in_html_document && !s.bytes().all(|b| b.to_ascii_lowercase() == b) {
                 continue;
             }
 
-            if !names.iter().any(|name| name == s) {
+            if seen.insert(s) {
                 names.push(DOMString::from(s));
             }
         }


### PR DESCRIPTION
⚡ Bolt: [performance improvement]

💡 What: Replaced O(N^2) array `.contains` checks with O(1) `HashSet` lookups in `SupportedPropertyNames` implementations across `HTMLCollection`, `HTMLFormElement`, and `NamedNodeMap`. Pre-allocated vectors where capacities were known.
🎯 Why: `SupportedPropertyNames` loops over DOM elements and checks for duplicate IDs/Names. Using an array to check for duplicates inside the loop makes the algorithm O(N^2), which can be slow for large collections.
📊 Impact: Reduces algorithmic complexity of deduplication from O(N^2) to O(N). Avoids unnecessary heap allocations (`DOMString`) by checking for duplicates using `Atom`/`&str` references first.
🔬 Measurement: Verify tests pass with `cargo test -p script_traits` and benchmark DOM queries that return named properties on large collections.

---
*PR created automatically by Jules for task [17781052901317559519](https://jules.google.com/task/17781052901317559519) started by @RingCanary*