### PR TITLE
⚡ Bolt: [performance improvement] O(1) string checks & O(N) deduplication for HTMLFormElement SupportedPropertyNames

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-27 - [Avoid to_string().is_empty() and O(N^2) deductions]
+**Learning:** Checking string emptiness by allocating with `.to_string().is_empty()` is wasteful when `.is_empty()` is natively available. Also, finding uniqueness in a Vec using `Vec::contains()` or `.iter().any()` inside a loop creates O(N^2) complexity.
+**Action:** Use `.is_empty()` directly on Atoms where possible, and use `HashSet::with_capacity` combined with `.insert()` to filter duplicates in O(N) time when converting vectors.

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -161,9 +161,9 @@ impl HTMLFormElement {
                 RadioListMode::ControlsExceptImageInputs => {
                     if child
                         .downcast::<HTMLElement>()
-                        .is_some_and(|c| c.is_listed_element()) &&
-                        (child.get_id().is_some_and(|i| i == *name) ||
-                            child.get_name().is_some_and(|n| n == *name))
+                        .is_some_and(|c| c.is_listed_element())
+                        && (child.get_id().is_some_and(|i| i == *name)
+                            || child.get_name().is_some_and(|n| n == *name))
                     {
                         if let Some(inp) = child.downcast::<HTMLInputElement>() {
                             // input, only return it if it's not image-button state
@@ -176,9 +176,9 @@ impl HTMLFormElement {
                     return false;
                 },
                 RadioListMode::Images => {
-                    return child.is::<HTMLImageElement>() &&
-                        (child.get_id().is_some_and(|i| i == *name) ||
-                            child.get_name().is_some_and(|n| n == *name));
+                    return child.is::<HTMLImageElement>()
+                        && (child.get_id().is_some_and(|i| i == *name)
+                            || child.get_name().is_some_and(|n| n == *name));
                 },
             }
         }
@@ -613,8 +613,8 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
         sourced_names_vec.sort_by(|a, b| {
             if a.element
                 .upcast::<Node>()
-                .CompareDocumentPosition(b.element.upcast::<Node>()) ==
-                0
+                .CompareDocumentPosition(b.element.upcast::<Node>())
+                == 0
             {
                 if a.source.is_past() && b.source.is_past() {
                     b.source.cmp(&a.source)
@@ -624,9 +624,9 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
             } else if a
                 .element
                 .upcast::<Node>()
-                .CompareDocumentPosition(b.element.upcast::<Node>()) &
-                NodeConstants::DOCUMENT_POSITION_FOLLOWING ==
-                NodeConstants::DOCUMENT_POSITION_FOLLOWING
+                .CompareDocumentPosition(b.element.upcast::<Node>())
+                & NodeConstants::DOCUMENT_POSITION_FOLLOWING
+                == NodeConstants::DOCUMENT_POSITION_FOLLOWING
             {
                 std::cmp::Ordering::Less
             } else {
@@ -635,12 +635,14 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
         });
 
         // Step 6
-        sourced_names_vec.retain(|sn| !sn.name.to_string().is_empty());
+        sourced_names_vec.retain(|sn| !sn.name.is_empty());
 
         // Step 7-8
-        let mut names_vec: Vec<DOMString> = Vec::new();
-        for elem in sourced_names_vec.iter() {
-            if !names_vec.iter().any(|name| *name == *elem.name) {
+        // O(N) deduplication using HashSet
+        let mut names_vec: Vec<DOMString> = Vec::with_capacity(sourced_names_vec.len());
+        let mut seen = std::collections::HashSet::with_capacity(sourced_names_vec.len());
+        for elem in sourced_names_vec.into_iter() {
+            if seen.insert(elem.name.clone()) {
                 names_vec.push(DOMString::from(&*elem.name));
             }
         }
@@ -909,11 +911,11 @@ impl HTMLFormElement {
                 );
             },
             // https://html.spec.whatwg.org/multipage/#submit-get-action
-            ("file", _) |
-            ("about", _) |
-            ("data", FormMethod::Post) |
-            ("ftp", _) |
-            ("javascript", _) => {
+            ("file", _)
+            | ("about", _)
+            | ("data", FormMethod::Post)
+            | ("ftp", _)
+            | ("javascript", _) => {
                 self.plan_to_navigate(load_data, target_window);
             },
             ("mailto", FormMethod::Post) => {
@@ -1399,11 +1401,11 @@ impl Element {
         };
         matches!(
             element_type,
-            HTMLElementTypeId::HTMLInputElement |
-                HTMLElementTypeId::HTMLSelectElement |
-                HTMLElementTypeId::HTMLTextAreaElement |
-                HTMLElementTypeId::HTMLOutputElement |
-                HTMLElementTypeId::HTMLElement
+            HTMLElementTypeId::HTMLInputElement
+                | HTMLElementTypeId::HTMLSelectElement
+                | HTMLElementTypeId::HTMLTextAreaElement
+                | HTMLElementTypeId::HTMLOutputElement
+                | HTMLElementTypeId::HTMLElement
         )
     }
 
@@ -1632,9 +1634,9 @@ pub(crate) trait FormControl: DomObject {
             .find_map(DomRoot::downcast::<HTMLFormElement>);
 
         // Step 1
-        if old_owner.is_some() &&
-            !(self.is_listed() && has_form_id) &&
-            nearest_form_ancestor == old_owner
+        if old_owner.is_some()
+            && !(self.is_listed() && has_form_id)
+            && nearest_form_ancestor == old_owner
         {
             return;
         }


### PR DESCRIPTION
**💡 What:** 
1. Replaced `!sn.name.to_string().is_empty()` with `!sn.name.is_empty()`.
2. Replaced O(N^2) `Vec::contains()` loop with an O(N) deduplication loop using `std::collections::HashSet` and pre-allocated vectors for `SupportedPropertyNames`.

**🎯 Why:**
1. Calling `.to_string()` on an `Atom` just to check if it is empty performs unnecessary heap allocations and string conversions.
2. The `SupportedPropertyNames` method previously searched the output vector (`names_vec`) for every element being inserted, resulting in an O(N^2) operation, which scales poorly when a form has many controls.

**📊 Impact:** 
- Eliminates unnecessary String allocations during empty checks.
- Reduces time complexity from O(N^2) to O(N) for deduplicating supported property names in HTML forms, improving performance on forms with large numbers of elements.

**🔬 Measurement:**
Run `cargo test -p script_traits` and verify that no logic has broken, and `cargo clippy -p script_traits` for linting.

---
*PR created automatically by Jules for task [10633128818546564536](https://jules.google.com/task/10633128818546564536) started by @RingCanary*