### PR TITLE
⚡ Bolt: [performance improvement] O(1) length for IFrameCollection

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-07-05 - O(1) Length for IFrameCollection
+**Learning:** `IFrameCollection` provides length through an iterator `.count()`, iterating over the underlying `Vec`, yielding O(N) operations. Because the elements are dynamically checked for root caching in `length()`, traversing takes O(N). But `IFrameCollection` already caches `IFrame` structures in `self.iframes: Vec<IFrame>`. The length is exactly `self.iframes.len()` in O(1).
+**Action:** When a struct wraps a `Vec` and needs a length method, implement it directly using `len()` instead of exposing an iterator that users map/count over.

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1365,9 +1365,9 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             let is_auxiliary = window_proxy.is_auxiliary();
 
             // https://html.spec.whatwg.org/multipage/#script-closable
-            let is_script_closable = (self.is_top_level() && history_length == 1) ||
-                is_auxiliary ||
-                pref!(dom_allow_scripts_to_close_windows);
+            let is_script_closable = (self.is_top_level() && history_length == 1)
+                || is_auxiliary
+                || pref!(dom_allow_scripts_to_close_windows);
 
             // TODO: rest of Step 3:
             // Is the incumbent settings object's responsible browsing context familiar with current?
@@ -1615,7 +1615,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     /// <https://html.spec.whatwg.org/multipage/#accessing-other-browsing-contexts>
     fn Length(&self) -> u32 {
-        self.Document().iframes().iter().count() as u32
+        self.Document().iframes().len() as u32
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-parent>
@@ -1814,8 +1814,8 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
                 iframe
                     .browsing_context_id()
                     .as_ref()
-                    .map(BrowsingContextId::to_string) ==
-                    Some(browsing_context_id.to_string())
+                    .map(BrowsingContextId::to_string)
+                    == Some(browsing_context_id.to_string())
             })
             .and_then(|iframe| iframe.GetContentWindow())
     }
@@ -2247,10 +2247,10 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
                     return true;
                 }
                 match type_ {
-                    HTMLElementTypeId::HTMLEmbedElement |
-                    HTMLElementTypeId::HTMLFormElement |
-                    HTMLElementTypeId::HTMLImageElement |
-                    HTMLElementTypeId::HTMLObjectElement => {
+                    HTMLElementTypeId::HTMLEmbedElement
+                    | HTMLElementTypeId::HTMLFormElement
+                    | HTMLElementTypeId::HTMLImageElement
+                    | HTMLElementTypeId::HTMLObjectElement => {
                         elem.get_name().as_ref() == Some(&self.name)
                     },
                     _ => false,
@@ -2568,8 +2568,8 @@ impl Window {
         // layouts (for queries and scrolling) are not blocked, as they do not display
         // anything and script expects the layout to be up-to-date after they run.
         let pipeline_id = self.pipeline_id();
-        if reflow_goal == ReflowGoal::UpdateTheRendering &&
-            self.layout_blocker.get().layout_blocked()
+        if reflow_goal == ReflowGoal::UpdateTheRendering
+            && self.layout_blocker.get().layout_blocked()
         {
             debug!("Suppressing pre-load-event reflow pipeline {pipeline_id}");
             return ReflowPhasesRun::empty();
@@ -2677,8 +2677,8 @@ impl Window {
         // See http://testthewebforward.org/docs/reftests.html
         // and https://web-platform-tests.org/writing-tests/crashtest.html
         if document.GetDocumentElement().is_some_and(|elem| {
-            elem.has_class(&atom!("reftest-wait"), CaseSensitivity::CaseSensitive) ||
-                elem.has_class(&Atom::from("test-wait"), CaseSensitivity::CaseSensitive)
+            elem.has_class(&atom!("reftest-wait"), CaseSensitivity::CaseSensitive)
+                || elem.has_class(&Atom::from("test-wait"), CaseSensitivity::CaseSensitive)
         }) {
             return;
         }
@@ -2691,8 +2691,8 @@ impl Window {
             return;
         }
 
-        if !self.pending_layout_images.borrow().is_empty() ||
-            !self.pending_images_for_rasterization.borrow().is_empty()
+        if !self.pending_layout_images.borrow().is_empty()
+            || !self.pending_images_for_rasterization.borrow().is_empty()
         {
             return;
         }
@@ -3784,10 +3784,10 @@ fn should_move_clip_rect(clip_rect: UntypedRect<Au>, new_viewport: UntypedRect<f
     static VIEWPORT_SCROLL_MARGIN_SIZE: f32 = 0.5;
     let viewport_scroll_margin = new_viewport.size * VIEWPORT_SCROLL_MARGIN_SIZE;
 
-    (clip_rect.origin.x - new_viewport.origin.x).abs() <= viewport_scroll_margin.width ||
-        (clip_rect.max_x() - new_viewport.max_x()).abs() <= viewport_scroll_margin.width ||
-        (clip_rect.origin.y - new_viewport.origin.y).abs() <= viewport_scroll_margin.height ||
-        (clip_rect.max_y() - new_viewport.max_y()).abs() <= viewport_scroll_margin.height
+    (clip_rect.origin.x - new_viewport.origin.x).abs() <= viewport_scroll_margin.width
+        || (clip_rect.max_x() - new_viewport.max_x()).abs() <= viewport_scroll_margin.width
+        || (clip_rect.origin.y - new_viewport.origin.y).abs() <= viewport_scroll_margin.height
+        || (clip_rect.max_y() - new_viewport.max_y()).abs() <= viewport_scroll_margin.height
 }
 
 impl Window {
@@ -3888,10 +3888,10 @@ fn is_named_element_with_name_attribute(elem: &Element) -> bool {
     };
     matches!(
         type_,
-        HTMLElementTypeId::HTMLEmbedElement |
-            HTMLElementTypeId::HTMLFormElement |
-            HTMLElementTypeId::HTMLImageElement |
-            HTMLElementTypeId::HTMLObjectElement
+        HTMLElementTypeId::HTMLEmbedElement
+            | HTMLElementTypeId::HTMLFormElement
+            | HTMLElementTypeId::HTMLImageElement
+            | HTMLElementTypeId::HTMLObjectElement
     )
 }
 

--- a/components/script/iframe_collection.rs
+++ b/components/script/iframe_collection.rs
@@ -164,6 +164,11 @@ impl IFrameCollection {
         }
     }
 
+    // O(1) length check for the underlying vector, bypassing ref-counting overhead.
+    pub(crate) fn len(&self) -> usize {
+        self.iframes.len()
+    }
+
     pub(crate) fn iter(&self) -> impl Iterator<Item = DomRoot<HTMLIFrameElement>> + use<'_> {
         self.iframes.iter().map(|iframe| iframe.element.as_rooted())
     }


### PR DESCRIPTION
💡 What: Replaced `self.Document().iframes().iter().count() as u32` with `self.Document().iframes().len() as u32` in `components/script/dom/window.rs`, exposing the underlying length of the cached `Vec` from `IFrameCollection`.
🎯 Why: `iter().count()` maps through `DomRoot` requiring unnecessary iteration and atomic reference counting.
📊 Impact: Reduces `Window::Length` operation from O(N) to O(1) avoiding any iterator or ARC overhead.
🔬 Measurement: Verify changes in `components/script/dom/window.rs` and `components/script/iframe_collection.rs` and run `cargo clippy -p script_traits` and `cargo test -p script_traits`.

---
*PR created automatically by Jules for task [1839489790241313160](https://jules.google.com/task/1839489790241313160) started by @RingCanary*